### PR TITLE
TypeScript implementation of the toll-fee calculator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+# Cancel superseded runs on the same branch / PR.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Type-check, lint, format and test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: TypeScript
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable corepack (installs the pnpm version pinned in package.json)
+        run: corepack enable
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: TypeScript/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm run typecheck
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Format check
+        run: pnpm run format:check
+
+      - name: Test with coverage
+        run: pnpm run test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: TypeScript/coverage/
+          retention-days: 7

--- a/TypeScript/.gitignore
+++ b/TypeScript/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+coverage/
+dist/
+*.tsbuildinfo
+.DS_Store
+.vscode/
+.idea/

--- a/TypeScript/.prettierignore
+++ b/TypeScript/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+coverage/
+dist/
+*.tsbuildinfo
+pnpm-lock.yaml
+package-lock.json

--- a/TypeScript/.prettierrc
+++ b/TypeScript/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/TypeScript/README.md
+++ b/TypeScript/README.md
@@ -1,0 +1,143 @@
+# `toll-calculator` — TypeScript implementation
+
+A pure TypeScript library for computing daily toll fees with hourly
+windowing, a daily cap, configurable fee bands and a pluggable holiday
+calendar. No HTTP server, no framework, no runtime dependencies.
+
+This folder is the TypeScript reimplementation of the reference Java / C#
+code at the repository root. The why-and-how lives in
+[`../docs/plan/`](../docs/plan/); the analysis of the reference code lives
+in [`../docs/discovery/`](../docs/discovery/).
+
+## Quick start
+
+Requires Node.js ≥ 20. The package manager (pnpm 10) is provisioned
+automatically by [Corepack][corepack], which ships with Node.
+
+```bash
+corepack enable        # one-time, no global install needed
+pnpm install           # installs dev deps
+pnpm test              # runs Vitest once
+```
+
+Other useful commands:
+
+| Command              | What it does                                  |
+| -------------------- | --------------------------------------------- |
+| `pnpm test:watch`    | Re-runs tests on file change.                 |
+| `pnpm test:coverage` | Runs tests and produces a coverage report.    |
+| `pnpm typecheck`     | `tsc --noEmit`.                               |
+| `pnpm lint`          | ESLint (flat config, type-aware rules).       |
+| `pnpm format`        | Prettier `--write`.                           |
+| `pnpm format:check`  | Prettier `--check` (used in CI).              |
+| `pnpm check`         | One-button: typecheck + lint + format + test. |
+
+## Using the library
+
+The 90% case — build a calculator from the bundled preset:
+
+```ts
+import { createTollCalculator, REFERENCE_PRESET } from "toll-calculator";
+
+const calc = createTollCalculator(REFERENCE_PRESET);
+
+const fee = calc.feeFor({ type: "Car" }, [
+  new Date("2025-09-17T06:25:00+02:00"),
+  new Date("2025-09-17T07:30:00+02:00"),
+  new Date("2025-09-17T16:00:00+02:00"),
+]);
+// fee === 44   (8 + 18 + 18)
+```
+
+The calculator returns `0` for toll-free vehicle types, for empty pass
+lists and for any pass that falls on a day flagged by the configured
+calendar. Within any rolling 60-minute window only the highest band fee
+counts, and the daily total is clamped to `dailyCap`.
+
+## Adding a new jurisdiction
+
+The library is jurisdiction-agnostic. A new "city" is a new preset:
+
+```ts
+import {
+  createTollCalculator,
+  REFERENCE_PRESET,
+  type TollCalculatorPreset,
+} from "toll-calculator";
+
+const MY_CITY_PRESET: TollCalculatorPreset = {
+  name: "my-city",
+  schedule: [
+    { from: "07:00", to: "08:59", fee: 25 },
+    { from: "16:00", to: "18:00", fee: 25 },
+  ],
+  calendar: { isHoliday: (date) => /* … */ false },
+  dailyCap: 100,
+  timeZone: "Europe/Oslo",
+};
+
+const calc = createTollCalculator(MY_CITY_PRESET);
+```
+
+Or keep the bundled calendar and override only what changes:
+
+```ts
+const calc = createTollCalculator({
+  ...REFERENCE_PRESET,
+  schedule: MY_CITY_SCHEDULE,
+  timeZone: "Europe/Oslo",
+});
+```
+
+Holiday sources can be stacked with `combineCalendars`:
+
+```ts
+import { combineCalendars, REFERENCE_PRESET } from "toll-calculator";
+
+const calc = createTollCalculator({
+  ...REFERENCE_PRESET,
+  calendar: combineCalendars(REFERENCE_PRESET.calendar, companyHolidayCalendar),
+});
+```
+
+## Public surface
+
+All consumer-facing exports live in `src/index.ts`:
+
+| Export                   | Kind        |
+| ------------------------ | ----------- |
+| `createTollCalculator`   | function    |
+| `combineCalendars`       | function    |
+| `REFERENCE_PRESET`       | const value |
+| `REFERENCE_FEE_SCHEDULE` | const value |
+| `Vehicle`, `VehicleType` | types       |
+| `FeeBand`, `FeeSchedule` | types       |
+| `HolidayCalendar`        | type        |
+| `TollCalculatorOptions`  | type        |
+| `TollCalculatorPreset`   | type        |
+| `TollCalculator`         | type        |
+
+See [`../docs/plan/04-domain-model.md`](../docs/plan/04-domain-model.md)
+for the full domain model.
+
+## Bugs in the reference code (absent in this implementation)
+
+The Java / C# code at the repository root has a number of correctness
+issues — documented in
+[`../docs/discovery/04-bugs.md`](../docs/discovery/04-bugs.md). None of
+them are reproduced here; the regression tests cover each one.
+
+## Conventions
+
+The codebase follows a small set of TypeScript conventions enforced by
+the type-checker and ESLint:
+
+- Callable interface members use **property syntax with arrow function
+  types**, never method shorthand — see `docs/plan/02-tech-stack.md`
+  §2.2.1 for the soundness rationale.
+- No `class`, no inheritance, no `this`. Factory functions returning
+  object literals only.
+- Every member of every public shape is `readonly`.
+- `interface` for object shapes; `type` for unions, arrays, tuples.
+
+[corepack]: https://nodejs.org/api/corepack.html

--- a/TypeScript/eslint.config.js
+++ b/TypeScript/eslint.config.js
@@ -1,0 +1,43 @@
+// @ts-check
+import { defineConfig } from "eslint/config";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default defineConfig([
+  {
+    ignores: ["node_modules", "coverage", "dist", "*.tsbuildinfo"],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.js"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  {
+    files: ["tests/**/*.ts"],
+    rules: {
+      // Tests are allowed to be loose about a few things.
+      "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+]);

--- a/TypeScript/package.json
+++ b/TypeScript/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "toll-calculator",
+  "version": "1.0.0",
+  "description": "Configurable toll fee calculator with hourly windowing, daily cap, and pluggable fee schedule and holiday calendar.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "pnpm@10.0.0",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test:coverage"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "@fast-check/vitest": "^0.4.1",
+    "@types/node": "^25.9.1",
+    "@vitest/coverage-v8": "^4.1.7",
+    "eslint": "^10.4.0",
+    "fast-check": "^4.8.0",
+    "prettier": "^3.8.3",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.4",
+    "vitest": "^4.1.7"
+  },
+  "dependencies": {
+    "@js-temporal/polyfill": "^0.5.1"
+  }
+}

--- a/TypeScript/pnpm-lock.yaml
+++ b/TypeScript/pnpm-lock.yaml
@@ -1,0 +1,1723 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@js-temporal/polyfill':
+        specifier: ^0.5.1
+        version: 0.5.1
+    devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.4.0)
+      '@fast-check/vitest':
+        specifier: ^0.4.1
+        version: 0.4.1(vitest@4.1.7)
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
+      eslint:
+        specifier: ^10.4.0
+        version: 10.4.0
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.59.4
+        version: 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1))
+
+packages:
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fast-check/vitest@0.4.1':
+    resolution: {integrity: sha512-OX6TecB+ZzRfPc49jcPChcV1cf5aDu77CdDU8liecWVam7eD7mPvJNP50b9bBSTxVoGN5wzxrX9PIcCnqgC8bg==}
+    peerDependencies:
+      vitest: ^4.1.0
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-temporal/polyfill@0.5.1':
+    resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
+    engines: {node: '>=12'}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@typescript-eslint/eslint-plugin@8.59.4':
+    resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.4
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.4':
+    resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.4':
+    resolution: {integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/coverage-v8@4.1.7':
+    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.7
+      vitest: 4.1.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.4.0:
+    resolution: {integrity: sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  jsbi@4.3.2:
+    resolution: {integrity: sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
+
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.59.4:
+    resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0)':
+    dependencies:
+      eslint: 10.4.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.4.0)':
+    optionalDependencies:
+      eslint: 10.4.0
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@fast-check/vitest@0.4.1(vitest@4.1.7)':
+    dependencies:
+      fast-check: 4.8.0
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1))
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-temporal/polyfill@0.5.1':
+    dependencies:
+      jsbi: 4.3.2
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@oxc-project/types@0.132.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/type-utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      eslint: 10.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      eslint: 10.4.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.4': {}
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.1
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      eslint: 10.4.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
+
+  '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.7
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1))
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@25.9.1)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  detect-libc@2.1.2: {}
+
+  es-module-lexer@2.1.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.4.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
+
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
+
+  jsbi@4.3.2: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.1
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  natural-compare@1.4.0: {}
+
+  obug@2.1.1: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
+
+  punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
+
+  semver@7.8.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  tslib@2.8.1:
+    optional: true
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.59.4(eslint@10.4.0)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      eslint: 10.4.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@6.0.3: {}
+
+  undici-types@7.24.6: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite@8.0.14(@types/node@25.9.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.9.1
+      fsevents: 2.3.3
+
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@25.9.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+    transitivePeerDependencies:
+      - msw
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/TypeScript/src/calculator.ts
+++ b/TypeScript/src/calculator.ts
@@ -1,0 +1,100 @@
+import type { Vehicle } from "./vehicle.js";
+import type { FeeSchedule } from "./fee-schedule.js";
+import type { HolidayCalendar } from "./calendar/index.js";
+import { isTollFreeVehicle } from "./vehicle.js";
+import { feeAt } from "./fee-schedule.js";
+import { parts } from "./time/zoned-time.js";
+import { assertVehicle, assertPasses } from "./validation.js";
+
+/**
+ * Configuration for {@link createTollCalculator}. Every field is required —
+ * the library is data-driven and refuses to guess defaults. Use a preset
+ * (e.g. `REFERENCE_PRESET`) and spread it to override only what differs.
+ */
+export interface TollCalculatorOptions {
+  /** Fee bands; see {@link FeeSchedule}. */
+  readonly schedule: FeeSchedule;
+  /** Holiday source; see {@link HolidayCalendar}. */
+  readonly calendar: HolidayCalendar;
+  /** Maximum total fee per day, in the schedule's currency. */
+  readonly dailyCap: number;
+  /** IANA time zone (e.g. "Europe/Stockholm") in which the schedule's wall-clock times are interpreted. */
+  readonly timeZone: string;
+}
+
+/**
+ * A named, ready-to-use bundle of {@link TollCalculatorOptions}. Presets
+ * are the suggested unit of distribution: each preset describes one
+ * jurisdiction's complete configuration (rates, calendar, cap, time zone).
+ *
+ * To add a new jurisdiction, export a new preset — no library changes
+ * required.
+ */
+export interface TollCalculatorPreset extends TollCalculatorOptions {
+  /** Human-readable identifier, e.g. "reference". */
+  readonly name: string;
+}
+
+/**
+ * The public calculator contract.
+ *
+ * - An empty `passes` array returns `0`.
+ * - Pass order is not significant; the calculator sorts internally and
+ *   does not mutate the caller's array.
+ * - Toll-free vehicles always return `0` regardless of passes.
+ * - Holidays (per `calendar`) make every pass on that day fee-free.
+ * - Within any 60-minute window, only the highest band fee counts.
+ * - The total is clamped to `dailyCap`.
+ */
+export interface TollCalculator {
+  readonly feeFor: (vehicle: Vehicle, passes: readonly Date[]) => number;
+}
+
+export const createTollCalculator = (
+  options: TollCalculatorOptions,
+): TollCalculator => {
+  const feeForPass = (date: Date): number => {
+    if (options.calendar.isHoliday(date)) return 0;
+    const { hour, minute } = parts(date, options.timeZone);
+    return feeAt(options.schedule, hour, minute);
+  };
+
+  const feeFor = (vehicle: Vehicle, passes: readonly Date[]): number => {
+    // Boundary validation — see `src/validation.ts` for the rationale.
+    // The TypeScript signature already forbids these shapes for in-process
+    // callers, but TS guarantees evaporate when input crosses any non-TS
+    // boundary (JSON.parse, ORM rows, plain-JS consumers). Validating
+    // here once means internal helpers never see malformed input.
+    assertVehicle(vehicle);
+    assertPasses(passes);
+
+    if (isTollFreeVehicle(vehicle)) return 0;
+
+    const [first, ...rest] = [...passes].sort(
+      (a, b) => a.getTime() - b.getTime(),
+    );
+    if (first === undefined) return 0;
+
+    let total = 0;
+    let windowStart = first;
+    let windowMax = feeForPass(first);
+
+    for (const pass of rest) {
+      const minutesFromAnchor =
+        (pass.getTime() - windowStart.getTime()) / 60_000;
+
+      if (minutesFromAnchor <= 60) {
+        windowMax = Math.max(windowMax, feeForPass(pass));
+      } else {
+        total += windowMax;
+        windowStart = pass;
+        windowMax = feeForPass(pass);
+      }
+    }
+    total += windowMax;
+
+    return Math.min(total, options.dailyCap);
+  };
+
+  return { feeFor };
+};

--- a/TypeScript/src/calendar/combine.ts
+++ b/TypeScript/src/calendar/combine.ts
@@ -1,0 +1,18 @@
+import type { HolidayCalendar } from "./index.js";
+
+/**
+ * Compose multiple calendars into one. The resulting calendar reports a
+ * day as a holiday if *any* of the inputs does.
+ *
+ * Useful for stacking sources of holiday data — e.g. a national calendar
+ * plus a company-specific calendar plus a local exception list — without
+ * each caller re-implementing the union logic.
+ *
+ * @example
+ * const calendar = combineCalendars(nationalHolidays, companyHolidays);
+ */
+export const combineCalendars = (
+  ...calendars: readonly HolidayCalendar[]
+): HolidayCalendar => ({
+  isHoliday: (date) => calendars.some((c) => c.isHoliday(date)),
+});

--- a/TypeScript/src/calendar/easter.ts
+++ b/TypeScript/src/calendar/easter.ts
@@ -1,0 +1,40 @@
+/**
+ * Returns the Gregorian date of Easter Sunday for the given year,
+ * computed via Gauss's algorithm with the 1807 and 1816 corrections.
+ * Pure integer arithmetic, valid for any Gregorian year (1583 onward).
+ *
+ * Algorithm:
+ *   Gauss, C. F. (1800). "Berechnung des Osterfestes."
+ *   Monatliche Correspondenz zur Beförderung der Erd- und Himmelskunde,
+ *   vol. 2, pp. 121–130.
+ *
+ * Transcribed from:
+ *   https://es.wikipedia.org/wiki/Computus (consulted 2026-05-23)
+ *
+ * Test fixtures cross-checked against the U.S. Naval Observatory's
+ * published table of Easter dates.
+ */
+export const easterSunday = (year: number): { month: number; day: number } => {
+  const a = year % 19;
+  const b = year % 4;
+  const c = year % 7;
+
+  const k = Math.floor(year / 100);
+  const p = Math.floor((13 + 8 * k) / 25);
+  const q = Math.floor(k / 4);
+  const M = (15 - p + k - q) % 30;
+  const N = (4 + k - q) % 7;
+
+  const d = (19 * a + M) % 30;
+  const e = (2 * b + 4 * c + 6 * d + N) % 7;
+
+  let day = d + e + 22;
+  let month = 3;
+  if (day > 31) {
+    day = d + e - 9;
+    month = 4;
+    if (day === 26) day = 19;
+    if (day === 25 && d === 28 && e === 6 && a > 10) day = 18;
+  }
+  return { month, day };
+};

--- a/TypeScript/src/calendar/index.ts
+++ b/TypeScript/src/calendar/index.ts
@@ -1,0 +1,13 @@
+/**
+ * A calendar that decides whether a given moment falls on a toll-free day.
+ *
+ * Implementations are free to consider weekends, fixed-date holidays,
+ * movable feasts (Easter-derived), the day before a public holiday, or
+ * any other rule the operating jurisdiction defines.
+ *
+ * The calculator treats holidays as a binary flag: if `isHoliday(date)`
+ * returns `true`, the entire day is free regardless of the fee schedule.
+ */
+export interface HolidayCalendar {
+  readonly isHoliday: (date: Date) => boolean;
+}

--- a/TypeScript/src/calendar/swedish.ts
+++ b/TypeScript/src/calendar/swedish.ts
@@ -1,0 +1,247 @@
+import { Temporal } from "@js-temporal/polyfill";
+import type { HolidayCalendar } from "./index.js";
+import { easterSunday } from "./easter.js";
+import { parts } from "../time/zoned-time.js";
+
+/**
+ * Swedish congestion-tax (trängselskatt) calendar — generalized to any
+ * Gregorian year by deriving the toll-free-day rules from primary Swedish
+ * legislation rather than reproducing a hard-coded year list.
+ *
+ * ## Legal sources
+ *
+ * - **SFS 2004:629** — *Lag om trängselskatt* ("Law on congestion tax"),
+ *   Bilaga 1 (the Stockholm-specific schedule). The relevant clause:
+ *
+ *   > "Skatt tas inte ut för fordon på lördagar, dag före söndag,
+ *   > helgdagar, dag före helgdag samt under juli månad … Skatt ska tas
+ *   > ut för dag före långfredagen, dag före Kristi himmelsfärdsdag, och
+ *   > dag före alla helgons dag … Under juli månad ska ingen skatt tas
+ *   > ut förutom för de fem första vardagarna utom lördag i den månaden."
+ *
+ *   English (informal): tax is *not* charged on Saturdays, the day before
+ *   Sunday, public holidays, days before public holidays, and during the
+ *   month of July — *except* that tax IS charged on the day before Good
+ *   Friday (Maundy Thursday), the day before Ascension Day (Ascension
+ *   Eve), the day before All Saints' Day (All Saints' Eve), and on the
+ *   first five non-Saturday weekdays of July.
+ *
+ *   Source: https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-2004629-om-trangselskatt_sfs-2004-629/
+ *
+ * - **SFS 1989:253** — *Lag om allmänna helgdagar* ("Law on general
+ *   public holidays"), §2, which enumerates the *helgdagar* referenced by
+ *   the previous law. Post-2005 reform: Sveriges nationaldag (June 6)
+ *   was added to the list; Annandag pingst (Whit Monday) was removed.
+ *
+ *   Source: https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/
+ *
+ * ## Algorithm
+ *
+ * For an instant interpreted in `Europe/Stockholm`, `isHoliday` returns
+ * `true` iff any of these holds (evaluated in order):
+ *
+ *   1. **Weekend.** Saturday or Sunday (ISO weekday ≥ 6).
+ *   2. **Public holiday** per SFS 1989:253 §2.
+ *   3. **July**, with the exception of the first five non-Saturday
+ *      weekdays of the month (SFS 2004:629 Bilaga 1 carve-out).
+ *   4. **Day before a public holiday**, unless the day is one of the
+ *      three explicitly taxed days listed in SFS 2004:629 Bilaga 1:
+ *      Maundy Thursday, Ascension Eve, or All Saints' Eve.
+ *
+ * ## Divergence from the bundled Java/C# reference
+ *
+ * The reference at the repo root hard-codes the 2013 list of toll-free
+ * days. That list flags Maundy Thursday, Ascension Eve, and Nov 1 (All
+ * Saints' Eve 2013) as free — the *opposite* of what SFS 2004:629
+ * mandates. It also marks the entire month of July as free, ignoring
+ * the first-five-weekdays carve-out. This implementation follows the
+ * law; see `docs/discovery/04-bugs.md` §4.6 for the trace.
+ *
+ * Per-year computations (Easter-derived dates, Midsummer Day, All Saints'
+ * Day, July taxed days) are memoized so a calculator invoked across many
+ * passes pays the cost once per distinct year.
+ */
+
+const STOCKHOLM = "Europe/Stockholm";
+
+/** Fixed-date public holidays per SFS 1989:253 §2 (M-D, no zero padding). */
+const FIXED_PUBLIC_HOLIDAYS: ReadonlySet<string> = new Set([
+  "1-1", // Nyårsdagen — New Year's Day
+  "1-6", // Trettondedag jul — Epiphany
+  "5-1", // Första maj — Workers' Day
+  "6-6", // Sveriges nationaldag — National Day (since 2005)
+  "12-25", // Juldagen — Christmas Day
+  "12-26", // Annandag jul — Boxing Day
+]);
+
+/** Day offsets from Easter Sunday for the Easter-derived helgdagar of SFS 1989:253 §2. */
+const EASTER_PUBLIC_HOLIDAY_OFFSETS: readonly number[] = [
+  -2, // Långfredagen — Good Friday
+  0, // Påskdagen — Easter Sunday
+  1, // Annandag påsk — Easter Monday
+  39, // Kristi himmelsfärdsdag — Ascension Day
+  49, // Pingstdagen — Whit Sunday
+];
+
+/**
+ * Day offsets from Easter Sunday for the SFS 2004:629 Bilaga 1
+ * day-before-holiday carve-outs (Maundy Thursday, Ascension Eve). The
+ * third carve-out, All Saints' Eve, is the Friday immediately before
+ * All Saints' Day and is handled separately because All Saints' Day is
+ * itself movable.
+ */
+const TAXED_DAY_BEFORE_OFFSETS_FROM_EASTER: readonly number[] = [
+  -3, // Skärtorsdagen — Maundy Thursday (day before Good Friday)
+  38, // Kristi himmelsfärds afton — Ascension Eve (day before Ascension Day)
+];
+
+interface EasterDerived {
+  readonly publicHolidays: ReadonlySet<string>;
+  readonly taxedDayBefore: ReadonlySet<string>;
+}
+
+const computeEasterDerived = (year: number): EasterDerived => {
+  const e = easterSunday(year);
+  const sunday = Temporal.PlainDate.from({ year, month: e.month, day: e.day });
+
+  const publicHolidays = new Set<string>();
+  for (const offset of EASTER_PUBLIC_HOLIDAY_OFFSETS) {
+    const d = sunday.add({ days: offset });
+    publicHolidays.add(`${String(d.month)}-${String(d.day)}`);
+  }
+
+  const taxedDayBefore = new Set<string>();
+  for (const offset of TAXED_DAY_BEFORE_OFFSETS_FROM_EASTER) {
+    const d = sunday.add({ days: offset });
+    taxedDayBefore.add(`${String(d.month)}-${String(d.day)}`);
+  }
+
+  return { publicHolidays, taxedDayBefore };
+};
+
+interface MovableSaturday {
+  readonly month: number;
+  readonly day: number;
+}
+
+/** Midsummer Day: Saturday between June 20 and June 26 (SFS 1989:253 §2). */
+const computeMidsummerDay = (year: number): MovableSaturday => {
+  for (let day = 20; day <= 26; day++) {
+    const d = Temporal.PlainDate.from({ year, month: 6, day });
+    if (d.dayOfWeek === 6) return { month: 6, day };
+  }
+  /* v8 ignore next 2 -- unreachable: any 7-day window contains exactly one Saturday */
+  throw new Error("unreachable: Jun 20-26 contains exactly one Saturday");
+};
+
+/** All Saints' Day: Saturday between October 31 and November 6 (SFS 1989:253 §2). */
+const computeAllSaintsDay = (year: number): MovableSaturday => {
+  let d = Temporal.PlainDate.from({ year, month: 10, day: 31 });
+  for (let i = 0; i < 7; i++) {
+    if (d.dayOfWeek === 6) return { month: d.month, day: d.day };
+    d = d.add({ days: 1 });
+  }
+  /* v8 ignore next 2 -- unreachable: Oct 31-Nov 6 contains exactly one Saturday */
+  throw new Error("unreachable: Oct 31-Nov 6 contains exactly one Saturday");
+};
+
+/**
+ * The first five non-Saturday weekdays (Mon–Fri) of July, per SFS
+ * 2004:629 Bilaga 1. These days *are* taxed despite July being otherwise
+ * toll-free.
+ */
+const computeJulyTaxedDays = (year: number): ReadonlySet<number> => {
+  const days = new Set<number>();
+  let d = Temporal.PlainDate.from({ year, month: 7, day: 1 });
+  while (days.size < 5) {
+    if (d.dayOfWeek >= 1 && d.dayOfWeek <= 5) {
+      days.add(d.day);
+    }
+    d = d.add({ days: 1 });
+  }
+  return days;
+};
+
+const memo = <T>(compute: (year: number) => T): ((year: number) => T) => {
+  const cache = new Map<number, T>();
+  return (year) => {
+    let value = cache.get(year);
+    if (value === undefined) {
+      value = compute(year);
+      cache.set(year, value);
+    }
+    return value;
+  };
+};
+
+export const createSwedishCongestionTaxCalendar = (): HolidayCalendar => {
+  const easterFor = memo(computeEasterDerived);
+  const midsummerFor = memo(computeMidsummerDay);
+  const allSaintsFor = memo(computeAllSaintsDay);
+  const julyTaxedFor = memo(computeJulyTaxedDays);
+
+  const isPublicHoliday = (
+    year: number,
+    month: number,
+    day: number,
+  ): boolean => {
+    const md = `${String(month)}-${String(day)}`;
+    if (FIXED_PUBLIC_HOLIDAYS.has(md)) return true;
+    if (easterFor(year).publicHolidays.has(md)) return true;
+    const mid = midsummerFor(year);
+    if (month === mid.month && day === mid.day) return true;
+    const asd = allSaintsFor(year);
+    if (month === asd.month && day === asd.day) return true;
+    return false;
+  };
+
+  const isCarveOutTaxed = (
+    year: number,
+    month: number,
+    day: number,
+  ): boolean => {
+    const md = `${String(month)}-${String(day)}`;
+    if (easterFor(year).taxedDayBefore.has(md)) return true;
+    const asd = allSaintsFor(year);
+    const eve = Temporal.PlainDate.from({
+      year,
+      month: asd.month,
+      day: asd.day,
+    }).subtract({ days: 1 });
+    if (month === eve.month && day === eve.day) return true;
+    return false;
+  };
+
+  const isHoliday = (date: Date): boolean => {
+    const p = parts(date, STOCKHOLM);
+
+    // 1. Weekend.
+    if (p.weekday >= 6) return true;
+
+    // 2. Public holiday per SFS 1989:253.
+    if (isPublicHoliday(p.year, p.month, p.day)) return true;
+
+    // 3. July: toll-free EXCEPT first five non-Saturday weekdays.
+    if (p.month === 7) {
+      const taxed = julyTaxedFor(p.year);
+      return !taxed.has(p.day);
+    }
+
+    // 4. Day before a public holiday — unless it is one of the three
+    //    carve-outs explicitly taxed by SFS 2004:629 Bilaga 1.
+    if (isCarveOutTaxed(p.year, p.month, p.day)) return false;
+
+    const tomorrow = Temporal.PlainDate.from({
+      year: p.year,
+      month: p.month,
+      day: p.day,
+    }).add({ days: 1 });
+    if (isPublicHoliday(tomorrow.year, tomorrow.month, tomorrow.day)) {
+      return true;
+    }
+
+    return false;
+  };
+
+  return { isHoliday };
+};

--- a/TypeScript/src/fee-schedule.ts
+++ b/TypeScript/src/fee-schedule.ts
@@ -1,0 +1,50 @@
+/**
+ * A fee band: every wall-clock minute in the inclusive range `[from, to]`
+ * is charged `fee`. Bands in a {@link FeeSchedule} must not overlap; any
+ * minute not covered by a band is implicitly fee-free.
+ */
+export interface FeeBand {
+  /** Inclusive lower bound as "HH:MM". */
+  readonly from: string;
+  /** Inclusive upper bound as "HH:MM". */
+  readonly to: string;
+  /** Fee charged for any pass within the band, in the schedule's currency. */
+  readonly fee: number;
+}
+
+/**
+ * Ordered, non-overlapping list of fee bands. Wall-clock semantics are
+ * defined by the time zone the calculator is configured with — the band
+ * times are interpreted in that zone.
+ */
+export type FeeSchedule = readonly FeeBand[];
+
+/**
+ * Returns the fee for the given wall-clock hour/minute according to the
+ * supplied schedule. Returns `0` for any time not covered by a band.
+ *
+ * Killing bug `[D§4.3]`: the schedule is plain data, so every minute is
+ * either inside a band (with the band's fee) or outside all of them
+ * (with `0`) — there is no `if`/`else` chain to forget a case.
+ */
+export const feeAt = (
+  schedule: FeeSchedule,
+  hour: number,
+  minute: number,
+): number => {
+  const target = hour * 60 + minute;
+  for (const band of schedule) {
+    if (target >= minutesOfDay(band.from) && target <= minutesOfDay(band.to)) {
+      return band.fee;
+    }
+  }
+  return 0;
+};
+
+const minutesOfDay = (hhmm: string): number => {
+  const [hh, mm] = hhmm.split(":");
+  if (hh === undefined || mm === undefined) {
+    throw new Error(`Invalid time format (expected "HH:MM"): ${hhmm}`);
+  }
+  return Number(hh) * 60 + Number(mm);
+};

--- a/TypeScript/src/index.ts
+++ b/TypeScript/src/index.ts
@@ -1,0 +1,19 @@
+// Public barrel — re-exports everything intended for consumers.
+//
+// Internal modules are not re-exported here. Keeping the surface small
+// makes it cheaper to evolve the implementation without breaking callers.
+
+export type { Vehicle, VehicleType } from "./vehicle.js";
+export type { FeeBand, FeeSchedule } from "./fee-schedule.js";
+export type { HolidayCalendar } from "./calendar/index.js";
+export { combineCalendars } from "./calendar/combine.js";
+export type {
+  TollCalculatorOptions,
+  TollCalculatorPreset,
+  TollCalculator,
+} from "./calculator.js";
+export { createTollCalculator } from "./calculator.js";
+export {
+  REFERENCE_PRESET,
+  REFERENCE_FEE_SCHEDULE,
+} from "./presets/reference.js";

--- a/TypeScript/src/presets/reference.ts
+++ b/TypeScript/src/presets/reference.ts
@@ -1,0 +1,64 @@
+import type { TollCalculatorPreset } from "../calculator.js";
+import type { FeeSchedule } from "../fee-schedule.js";
+import { createSwedishCongestionTaxCalendar } from "../calendar/swedish.js";
+
+/**
+ * Fee schedule derived from the reference Java / C# implementation shipped
+ * in this repository. Amounts are in SEK (the only currency mentioned in
+ * the assignment README).
+ *
+ * Wall-clock band boundaries are interpreted in the time zone supplied via
+ * {@link REFERENCE_PRESET}.timeZone.
+ *
+ * Differences from the reference Java code:
+ * - The 08:30–14:59 band correctly covers every minute (the reference
+ *   only covered minutes 30–59 of hours 9–14, leaving 09:00–14:29
+ *   accidentally free — see `docs/discovery/04-bugs.md` §4.3).
+ * - The 15:30–16:59 band is expressed cleanly as a single range (the
+ *   reference used a confusing `||` with a precedence bug).
+ */
+export const REFERENCE_FEE_SCHEDULE: FeeSchedule = [
+  { from: "06:00", to: "06:29", fee: 8 },
+  { from: "06:30", to: "06:59", fee: 13 },
+  { from: "07:00", to: "07:59", fee: 18 },
+  { from: "08:00", to: "08:29", fee: 13 },
+  { from: "08:30", to: "14:59", fee: 8 },
+  { from: "15:00", to: "15:29", fee: 13 },
+  { from: "15:30", to: "16:59", fee: 18 },
+  { from: "17:00", to: "17:59", fee: 13 },
+  { from: "18:00", to: "18:29", fee: 8 },
+];
+
+/**
+ * Default preset bundling the schedule, calendar, daily cap and time zone
+ * derived from primary Swedish legislation:
+ *
+ * - **Schedule + cap** mirror the bundled Java / C# reference (SEK
+ *   amounts, 60 SEK daily cap).
+ * - **Calendar** is computed from SFS 2004:629 (Lag om trängselskatt)
+ *   Bilaga 1 and SFS 1989:253 (Lag om allmänna helgdagar) — see
+ *   `src/calendar/swedish.ts` for the citation block and algorithm.
+ * - **Time zone** `Europe/Stockholm` is a data property of the preset
+ *   because the schedule's wall-clock semantics were defined for that
+ *   zone. Consumers using a different rate table override `timeZone`
+ *   (and the other fields) by spreading this preset into their options.
+ *
+ * @example
+ * import { createTollCalculator, REFERENCE_PRESET } from "toll-calculator";
+ * const calc = createTollCalculator(REFERENCE_PRESET);
+ *
+ * @example
+ * // Custom city — keep the calendar, override schedule and zone:
+ * const calc = createTollCalculator({
+ *   ...REFERENCE_PRESET,
+ *   schedule: MY_CITY_SCHEDULE,
+ *   timeZone: "Europe/Oslo",
+ * });
+ */
+export const REFERENCE_PRESET: TollCalculatorPreset = {
+  name: "reference",
+  schedule: REFERENCE_FEE_SCHEDULE,
+  calendar: createSwedishCongestionTaxCalendar(),
+  dailyCap: 60,
+  timeZone: "Europe/Stockholm",
+};

--- a/TypeScript/src/time/diff.ts
+++ b/TypeScript/src/time/diff.ts
@@ -1,0 +1,20 @@
+/**
+ * Difference between two moments, in whole-or-fractional minutes.
+ *
+ * The arithmetic is on UTC milliseconds, so the result is independent of
+ * any time zone and unaffected by DST transitions — exactly what the
+ * 60-minute-window rule needs. A pass at 02:30 CET and a pass at 03:30
+ * CEST on a spring-forward Sunday are *one hour apart* in UTC even
+ * though the wall clock advanced two hours; this function returns 60.
+ *
+ * We use raw `Date.getTime()` rather than `Temporal.Duration` because the
+ * computation is a single subtraction; reaching for Temporal here would
+ * be ceremony without benefit. The DST-correctness story lives in
+ * `zoned-time.ts`, not here.
+ *
+ * Killing bug `[D§4.1]`: the C# reference computed minutes by subtracting
+ * `DateTime.Millisecond` (the ms-within-second component) rather than the
+ * raw tick value. `getTime()` returns the raw ms since epoch — no trap.
+ */
+export const minutesBetween = (earlier: Date, later: Date): number =>
+  (later.getTime() - earlier.getTime()) / 60_000;

--- a/TypeScript/src/time/zoned-time.ts
+++ b/TypeScript/src/time/zoned-time.ts
@@ -1,0 +1,52 @@
+import { Temporal } from "@js-temporal/polyfill";
+
+/**
+ * Wall-clock parts of a moment in time, interpreted in a specific IANA
+ * time zone. `month` is 1-12 (calendar convention, not the JS `Date`
+ * 0-indexed convention), and `weekday` is ISO 1=Monday … 7=Sunday so
+ * that weekend detection is a single `weekday >= 6` comparison.
+ */
+export interface ZonedParts {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+  readonly hour: number;
+  readonly minute: number;
+  readonly weekday: number;
+}
+
+/**
+ * Returns the wall-clock parts of `date` as interpreted in `timeZone`.
+ *
+ * Implementation uses the TC39 Temporal API via `@js-temporal/polyfill`.
+ * When Temporal ships natively in V8 / Node, the polyfill import becomes
+ * the only line that needs to change — the call sites are spec-final.
+ *
+ * Why a library instead of `Intl.DateTimeFormat`: `Date` has no native
+ * way to ask "what wall-clock does this instant produce in city X?";
+ * `Intl.DateTimeFormat` only solves the string-formatting half of that
+ * problem and leaves zone arithmetic (DST ambiguity, weekday derivation,
+ * locale-sensitive parsing) to the caller. Temporal exposes the
+ * arithmetic directly. See `docs/plan/02-tech-stack.md` §2.5 for the
+ * alternatives evaluated.
+ *
+ * Killing bug `[D§4.1]`: the C# reference subtracts `DateTime.Millisecond`
+ * and ignores zones entirely. Here every consumer must pass an explicit
+ * IANA zone — there is no implicit "local time".
+ *
+ * @throws RangeError if `timeZone` is not a valid IANA zone identifier.
+ */
+export const parts = (date: Date, timeZone: string): ZonedParts => {
+  const zonedDateTime = Temporal.Instant.fromEpochMilliseconds(
+    date.getTime(),
+  ).toZonedDateTimeISO(timeZone);
+
+  return {
+    year: zonedDateTime.year,
+    month: zonedDateTime.month,
+    day: zonedDateTime.day,
+    hour: zonedDateTime.hour,
+    minute: zonedDateTime.minute,
+    weekday: zonedDateTime.dayOfWeek,
+  };
+};

--- a/TypeScript/src/validation.ts
+++ b/TypeScript/src/validation.ts
@@ -1,0 +1,52 @@
+import type { Vehicle } from "./vehicle.js";
+
+/**
+ * Boundary validators for the public calculator entry point.
+ *
+ * Why these exist even though the TypeScript signatures already forbid
+ * `null` / `undefined` / invalid `Date`:
+ *
+ * TypeScript's guarantees vanish at runtime. The realistic origins of
+ * malformed input to a library like this are:
+ *   - `JSON.parse(apiResponse)` — a remote contract change ships strings
+ *     where we expected `Date`s.
+ *   - A database row mapped by an under-typed ORM.
+ *   - A plain-JS caller, or any code that erased types via `as any`.
+ *
+ * In all three cases the type system already let the input through. The
+ * job of these `asserts` helpers is to turn the failure into a clear
+ * error at the boundary — *before* the value reaches the windowing
+ * algorithm, where the eventual `Cannot read properties of null` is
+ * useless to whoever is debugging the caller.
+ *
+ * Implementation note: each helper takes `unknown`, so the checks have
+ * genuine type overlap and ESLint's `no-unnecessary-condition` rule is
+ * satisfied without disabling it. From the caller's perspective the
+ * narrowing is a no-op (we pass a value that is already typed `Vehicle`
+ * or `readonly Date[]`), but the runtime check still runs.
+ */
+
+export function assertVehicle(value: unknown): asserts value is Vehicle {
+  if (value === null || value === undefined) {
+    throw new TypeError(
+      "feeFor: `vehicle` is required (received null/undefined)",
+    );
+  }
+  if (typeof value !== "object" || !("type" in value)) {
+    throw new TypeError(
+      "feeFor: `vehicle` must be an object with a `type` property",
+    );
+  }
+}
+
+export function assertPasses(value: unknown): asserts value is readonly Date[] {
+  if (!Array.isArray(value)) {
+    throw new TypeError("feeFor: `passes` must be an array");
+  }
+  for (let i = 0; i < value.length; i++) {
+    const pass: unknown = value[i];
+    if (!(pass instanceof Date) || Number.isNaN(pass.getTime())) {
+      throw new RangeError(`feeFor: passes[${String(i)}] is not a valid Date`);
+    }
+  }
+}

--- a/TypeScript/src/vehicle.ts
+++ b/TypeScript/src/vehicle.ts
@@ -1,0 +1,34 @@
+/**
+ * Discriminator for {@link Vehicle}. A string literal union, not an enum:
+ * enums emit a runtime object that we do not need, and a union plays well
+ * with exhaustive `switch` checks via `never`.
+ */
+export type VehicleType =
+  | "Car"
+  | "Motorbike"
+  | "Tractor"
+  | "Emergency"
+  | "Diplomat"
+  | "Foreign"
+  | "Military";
+
+export interface Vehicle {
+  readonly type: VehicleType;
+}
+
+/**
+ * Set of vehicle types that are always exempt from tolls. Membership is
+ * a `Set` lookup, not a chain of string equality checks — kills bug
+ * `[D§4.7]` from the reference code.
+ */
+const TOLL_FREE_TYPES: ReadonlySet<VehicleType> = new Set<VehicleType>([
+  "Motorbike",
+  "Tractor",
+  "Emergency",
+  "Diplomat",
+  "Foreign",
+  "Military",
+]);
+
+export const isTollFreeVehicle = (vehicle: Vehicle): boolean =>
+  TOLL_FREE_TYPES.has(vehicle.type);

--- a/TypeScript/tests/calculator.property.test.ts
+++ b/TypeScript/tests/calculator.property.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect } from "vitest";
+import { fc, test } from "@fast-check/vitest";
+import { createTollCalculator } from "../src/calculator.js";
+import type { Vehicle, VehicleType } from "../src/vehicle.js";
+import type { FeeSchedule } from "../src/fee-schedule.js";
+import type { HolidayCalendar } from "../src/calendar/index.js";
+
+/**
+ * Property-based tests via fast-check. Each property covers an infinite
+ * family of inputs and asserts an invariant the calculator must satisfy
+ * for *every* member of the family. A counter-example shrinks to the
+ * minimal failing case automatically.
+ *
+ * Properties live here, not in `calculator.test.ts`, so a reviewer can
+ * see at a glance which invariants are tested generatively vs by
+ * example. The four properties match `docs/plan/05-testing-strategy.md`
+ * §5.3.
+ */
+
+const TEST_SCHEDULE: FeeSchedule = [
+  { from: "06:00", to: "06:29", fee: 8 },
+  { from: "06:30", to: "06:59", fee: 13 },
+  { from: "07:00", to: "07:59", fee: 18 },
+  { from: "08:00", to: "08:29", fee: 13 },
+  { from: "08:30", to: "14:59", fee: 8 },
+  { from: "15:00", to: "15:29", fee: 13 },
+  { from: "15:30", to: "16:59", fee: 18 },
+  { from: "17:00", to: "17:59", fee: 13 },
+  { from: "18:00", to: "18:29", fee: 8 },
+];
+
+const DAILY_CAP = 60;
+const NEVER_HOLIDAY: HolidayCalendar = { isHoliday: () => false };
+
+const calc = createTollCalculator({
+  schedule: TEST_SCHEDULE,
+  calendar: NEVER_HOLIDAY,
+  dailyCap: DAILY_CAP,
+  timeZone: "UTC",
+});
+
+const CAR: Vehicle = { type: "Car" };
+
+const TOLL_FREE_TYPES: readonly VehicleType[] = [
+  "Motorbike",
+  "Tractor",
+  "Emergency",
+  "Diplomat",
+  "Foreign",
+  "Military",
+];
+
+/**
+ * Arbitrary date within a sensible range. `noInvalidDate: true` ensures
+ * no `NaN`-time Date objects (which `assertPasses` would reject and
+ * derail the property).
+ */
+const dateArb = fc.date({
+  min: new Date("2024-01-01T00:00:00Z"),
+  max: new Date("2030-12-31T23:59:59Z"),
+  noInvalidDate: true,
+});
+
+describe("calculator — properties (fast-check)", () => {
+  test.prop([fc.array(dateArb, { maxLength: 50 })])(
+    "(1) `feeFor(Car, passes)` never exceeds `dailyCap`",
+    (passes) => {
+      expect(calc.feeFor(CAR, passes)).toBeLessThanOrEqual(DAILY_CAP);
+    },
+  );
+
+  test.prop([
+    fc.constantFrom(...TOLL_FREE_TYPES),
+    fc.array(dateArb, { maxLength: 50 }),
+  ])(
+    "(2) toll-free vehicles always return 0, regardless of passes",
+    (type, passes) => {
+      expect(calc.feeFor({ type }, passes)).toBe(0);
+    },
+  );
+
+  test.prop([fc.array(dateArb, { maxLength: 30 })])(
+    "(3) `feeFor` is order-independent — `f(passes) === f(shuffle(passes))`",
+    (passes) => {
+      const shuffled = [...passes].reverse();
+      expect(calc.feeFor(CAR, passes)).toBe(calc.feeFor(CAR, shuffled));
+    },
+  );
+
+  test.prop([fc.array(dateArb, { maxLength: 20 }), dateArb])(
+    "(4) `feeFor` is monotone — adding a pass never decreases the total",
+    (passes, extra) => {
+      const before = calc.feeFor(CAR, passes);
+      const after = calc.feeFor(CAR, [...passes, extra]);
+      expect(after).toBeGreaterThanOrEqual(before);
+    },
+  );
+});

--- a/TypeScript/tests/calculator.test.ts
+++ b/TypeScript/tests/calculator.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import { createTollCalculator } from "../src/calculator.js";
+import type {
+  TollCalculator,
+  TollCalculatorOptions,
+} from "../src/calculator.js";
+import type { Vehicle } from "../src/vehicle.js";
+import type { FeeSchedule } from "../src/fee-schedule.js";
+import type { HolidayCalendar } from "../src/calendar/index.js";
+
+/**
+ * Unit tests for `createTollCalculator` — exercise the windowing, cap,
+ * sorting and vehicle/calendar short-circuits with a **mocked** schedule
+ * and calendar. The point is that a failure here points at the
+ * calculator's mechanics, not at the bundled reference data or the
+ * Swedish calendar. End-to-end behavior through the real preset is
+ * covered by `integration.test.ts`.
+ */
+
+const TEST_SCHEDULE: FeeSchedule = [
+  { from: "06:00", to: "06:29", fee: 8 },
+  { from: "06:30", to: "06:59", fee: 13 },
+  { from: "07:00", to: "07:59", fee: 18 },
+  { from: "08:00", to: "08:29", fee: 13 },
+  { from: "08:30", to: "14:59", fee: 8 },
+  { from: "15:00", to: "15:29", fee: 13 },
+  { from: "15:30", to: "16:59", fee: 18 },
+  { from: "17:00", to: "17:59", fee: 13 },
+  { from: "18:00", to: "18:29", fee: 8 },
+];
+
+const NEVER_HOLIDAY: HolidayCalendar = { isHoliday: () => false };
+const ALWAYS_HOLIDAY: HolidayCalendar = { isHoliday: () => true };
+
+const flagging = (...flagged: Date[]): HolidayCalendar => ({
+  isHoliday: (date) => flagged.some((d) => d.getTime() === date.getTime()),
+});
+
+const calculatorWith = (
+  calendar: HolidayCalendar,
+  overrides: Partial<TollCalculatorOptions> = {},
+): TollCalculator =>
+  createTollCalculator({
+    schedule: TEST_SCHEDULE,
+    calendar,
+    dailyCap: 60,
+    timeZone: "UTC",
+    ...overrides,
+  });
+
+/** Build a UTC instant whose wall-clock hour/minute matches the string. */
+const at = (hhmm: string): Date => new Date(`2025-01-15T${hhmm}:00Z`);
+
+const car: Vehicle = { type: "Car" };
+
+describe("createTollCalculator — table-driven scenarios", () => {
+  it("row 1 — single rush-hour pass charges the band fee", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    expect(calc.feeFor(car, [at("07:15")])).toBe(18);
+  });
+
+  it("row 2 — two passes in the same 60-min window charge the window max", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    // 07:15 (18) + 07:45 (18) — same band, same window.
+    expect(calc.feeFor(car, [at("07:15"), at("07:45")])).toBe(18);
+  });
+
+  it("row 3 — passes in different windows are both charged", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    // 07:15 (band 07:00–07:59 = 18) + 08:25 (band 08:00–08:29 = 13).
+    // 70 min apart → two separate windows.
+    expect(calc.feeFor(car, [at("07:15"), at("08:25")])).toBe(31);
+  });
+
+  it("row 4 — four windows across the day sum to 57", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    // 06:15 (8) | 07:30 (18) | 15:30 (18) | 17:30 (13).
+    expect(
+      calc.feeFor(car, [at("06:15"), at("07:30"), at("15:30"), at("17:30")]),
+    ).toBe(57);
+  });
+
+  it("row 5 — total above 60 is clamped to dailyCap", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    // Five separate windows at 18 = 90 uncapped → clamped to 60.
+    expect(
+      calc.feeFor(car, [
+        at("07:00"),
+        at("08:05"),
+        at("15:30"),
+        at("16:35"),
+        at("17:40"),
+      ]),
+    ).toBe(60);
+  });
+
+  it("row 6 — toll-free vehicle always returns 0", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    const motorbike: Vehicle = { type: "Motorbike" };
+    // Same passes that would be 57 for a Car.
+    expect(
+      calc.feeFor(motorbike, [
+        at("06:15"),
+        at("07:30"),
+        at("15:30"),
+        at("17:30"),
+      ]),
+    ).toBe(0);
+  });
+
+  it("row 7 — every pass on a calendar-flagged day returns 0", () => {
+    const calc = calculatorWith(ALWAYS_HOLIDAY);
+    expect(calc.feeFor(car, [at("07:00"), at("08:00"), at("16:00")])).toBe(0);
+  });
+
+  it("row 8 — calendar can flag specific instants only (others bill normally)", () => {
+    const flaggedPass = at("07:30");
+    const calc = calculatorWith(flagging(flaggedPass));
+    // 07:30 is flagged → 0 inside the window.
+    // 08:00 (13) is in the same 60-min window as 07:30; windowMax = max(0, 13) = 13.
+    expect(calc.feeFor(car, [flaggedPass, at("08:00")])).toBe(13);
+  });
+
+  it("row 9 — empty pass list returns 0 without throwing", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    expect(calc.feeFor(car, [])).toBe(0);
+  });
+
+  it("row 10 — unsorted passes yield the same total as the sorted equivalent", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    const sorted = [at("06:15"), at("07:30"), at("15:30"), at("17:30")];
+    const shuffled = [at("17:30"), at("06:15"), at("15:30"), at("07:30")];
+    expect(calc.feeFor(car, shuffled)).toBe(calc.feeFor(car, sorted));
+  });
+
+  it("row 10b — feeFor does NOT mutate the caller's array", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    const passes = [at("17:30"), at("06:15"), at("15:30"), at("07:30")];
+    const snapshot = [...passes];
+    calc.feeFor(car, passes);
+    expect(passes).toEqual(snapshot);
+  });
+
+  it("row 11 — passes entirely outside any band return 0", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    // 01:00, 03:30, 05:00 — all before 06:00, no fee band covers them.
+    expect(calc.feeFor(car, [at("01:00"), at("03:30"), at("05:00")])).toBe(0);
+  });
+
+  it("row 12 — boundary minutes match the schedule exactly", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    expect(calc.feeFor(car, [at("06:00")])).toBe(8); // band 06:00–06:29 from
+    expect(calc.feeFor(car, [at("06:29")])).toBe(8); // band 06:00–06:29 to
+    expect(calc.feeFor(car, [at("06:30")])).toBe(13); // band 06:30–06:59 from
+    expect(calc.feeFor(car, [at("18:29")])).toBe(8); // last band's to
+    expect(calc.feeFor(car, [at("18:30")])).toBe(0); // one minute past last band
+  });
+
+  it("row 13 — same-millisecond duplicate passes are charged once", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY);
+    const instant = at("07:15"); // fee=18
+    // Three identical instants — windowed together at max=18, charged once.
+    expect(calc.feeFor(car, [instant, instant, instant])).toBe(18);
+  });
+});
+
+describe("createTollCalculator — configurable behavior", () => {
+  it("respects a custom dailyCap (lower)", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY, { dailyCap: 20 });
+    // Two non-overlapping windows: 18 + 13 = 31 → clamped to 20.
+    expect(calc.feeFor(car, [at("07:00"), at("08:30")])).toBe(20);
+  });
+
+  it("respects a custom dailyCap (higher)", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY, { dailyCap: 1000 });
+    // Same scenario that capped at 60 above; no clamping at 1000.
+    expect(
+      calc.feeFor(car, [
+        at("07:00"),
+        at("08:05"),
+        at("15:30"),
+        at("16:35"),
+        at("17:40"),
+      ]),
+    ).toBe(80);
+  });
+
+  it("respects a different fee schedule", () => {
+    const calc = calculatorWith(NEVER_HOLIDAY, {
+      schedule: [{ from: "00:00", to: "23:59", fee: 5 }],
+    });
+    expect(calc.feeFor(car, [at("12:00")])).toBe(5);
+    expect(calc.feeFor(car, [at("23:59")])).toBe(5);
+  });
+});

--- a/TypeScript/tests/combine-calendars.test.ts
+++ b/TypeScript/tests/combine-calendars.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { combineCalendars } from "../src/calendar/combine.js";
+import type { HolidayCalendar } from "../src/calendar/index.js";
+
+const calendarOf = (predicate: (date: Date) => boolean): HolidayCalendar => ({
+  isHoliday: predicate,
+});
+
+const ANY_DATE = new Date("2025-09-17T12:00:00Z");
+
+describe("combineCalendars", () => {
+  it("returns a calendar that flags nothing when given no inputs", () => {
+    const combined = combineCalendars();
+    expect(combined.isHoliday(ANY_DATE)).toBe(false);
+  });
+
+  it("delegates to a single calendar (pass-through)", () => {
+    const always = calendarOf(() => true);
+    const never = calendarOf(() => false);
+
+    expect(combineCalendars(always).isHoliday(ANY_DATE)).toBe(true);
+    expect(combineCalendars(never).isHoliday(ANY_DATE)).toBe(false);
+  });
+
+  it("returns true if ANY input calendar reports the date as a holiday (OR semantics)", () => {
+    const never = calendarOf(() => false);
+    const always = calendarOf(() => true);
+
+    expect(combineCalendars(never, never, always).isHoliday(ANY_DATE)).toBe(
+      true,
+    );
+    expect(combineCalendars(never, never, never).isHoliday(ANY_DATE)).toBe(
+      false,
+    );
+  });
+
+  it("evaluates each input independently per date", () => {
+    const dayA = new Date("2025-01-01T12:00:00Z");
+    const dayB = new Date("2025-02-02T12:00:00Z");
+    const dayC = new Date("2025-03-03T12:00:00Z");
+
+    const onlyA = calendarOf((d) => d.getTime() === dayA.getTime());
+    const onlyB = calendarOf((d) => d.getTime() === dayB.getTime());
+
+    const combined = combineCalendars(onlyA, onlyB);
+
+    expect(combined.isHoliday(dayA)).toBe(true);
+    expect(combined.isHoliday(dayB)).toBe(true);
+    expect(combined.isHoliday(dayC)).toBe(false);
+  });
+});

--- a/TypeScript/tests/easter.test.ts
+++ b/TypeScript/tests/easter.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { easterSunday } from "../src/calendar/easter.js";
+
+/**
+ * Reference Easter dates (Gregorian). Cross-checked against:
+ *   - U.S. Naval Observatory, "Dates of Easter Sunday"
+ *   - Meeus, J. (1998). Astronomical Algorithms, 2nd ed., ch. 8.
+ */
+const KNOWN_EASTERS: readonly (readonly [number, number, number])[] = [
+  [1961, 4, 2], // Meeus's worked example
+  [1981, 4, 19], // exercises the april_easter==26 → 19 correction
+  [2000, 4, 23],
+  [2013, 3, 31], // the year of the bundled reference data
+  [2024, 3, 31],
+  [2025, 4, 20],
+  [2026, 4, 5],
+  [2038, 4, 25], // exercises the april_easter==25 boundary
+];
+
+describe("easterSunday", () => {
+  for (const [year, month, day] of KNOWN_EASTERS) {
+    it(`returns ${String(year)}-${String(month)}-${String(day)} for ${String(year)}`, () => {
+      expect(easterSunday(year)).toEqual({ month, day });
+    });
+  }
+
+  it("falls within March 22 – April 25 inclusive for every year 1583–2500", () => {
+    for (let year = 1583; year <= 2500; year++) {
+      const { month, day } = easterSunday(year);
+      const ordinal = month === 3 ? day : day + 31;
+      expect(ordinal).toBeGreaterThanOrEqual(22);
+      expect(ordinal).toBeLessThanOrEqual(56);
+    }
+  });
+});

--- a/TypeScript/tests/fee-schedule.test.ts
+++ b/TypeScript/tests/fee-schedule.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { feeAt } from "../src/fee-schedule.js";
+import type { FeeSchedule } from "../src/fee-schedule.js";
+import { REFERENCE_FEE_SCHEDULE } from "../src/index.js";
+
+/**
+ * `feeAt` tests use a minimal, hand-rolled schedule so that failures point
+ * at the lookup logic, not at the reference data. The reference schedule
+ * is exercised separately in the section below.
+ */
+describe("feeAt", () => {
+  const schedule: FeeSchedule = [
+    { from: "06:00", to: "06:29", fee: 8 },
+    { from: "07:00", to: "07:59", fee: 18 },
+  ];
+
+  it("returns the band fee at its from boundary (inclusive)", () => {
+    expect(feeAt(schedule, 6, 0)).toBe(8);
+    expect(feeAt(schedule, 7, 0)).toBe(18);
+  });
+
+  it("returns the band fee at its to boundary (inclusive)", () => {
+    expect(feeAt(schedule, 6, 29)).toBe(8);
+    expect(feeAt(schedule, 7, 59)).toBe(18);
+  });
+
+  it("returns the band fee at the midpoint", () => {
+    expect(feeAt(schedule, 6, 15)).toBe(8);
+    expect(feeAt(schedule, 7, 30)).toBe(18);
+  });
+
+  it("returns 0 in the gap between bands", () => {
+    expect(feeAt(schedule, 6, 30)).toBe(0);
+    expect(feeAt(schedule, 6, 45)).toBe(0);
+    expect(feeAt(schedule, 6, 59)).toBe(0);
+  });
+
+  it("returns 0 before the first band", () => {
+    expect(feeAt(schedule, 0, 0)).toBe(0);
+    expect(feeAt(schedule, 5, 59)).toBe(0);
+  });
+
+  it("returns 0 after the last band", () => {
+    expect(feeAt(schedule, 8, 0)).toBe(0);
+    expect(feeAt(schedule, 23, 59)).toBe(0);
+  });
+
+  it("returns 0 on an empty schedule", () => {
+    expect(feeAt([], 12, 0)).toBe(0);
+  });
+
+  it("rejects malformed band times with a clear error", () => {
+    const bad: FeeSchedule = [{ from: "06", to: "06:29", fee: 8 }];
+    expect(() => feeAt(bad, 6, 0)).toThrow(/Invalid time format/);
+  });
+});
+
+/**
+ * Meta-tests on REFERENCE_FEE_SCHEDULE. These run against the actual data
+ * shipped with the library, not a sample. Together they guarantee:
+ *   • No two bands overlap (would be a data bug).
+ *   • Every minute in 06:00–18:29 is covered by exactly one band
+ *     (specifically catches the "missing 09:00–14:29 hole" from bug
+ *     `[D§4.3]` in the reference Java code).
+ *   • Every minute outside 06:00–18:29 is covered by zero bands
+ *     (no surprise fees at 03:00 or 22:00).
+ */
+describe("REFERENCE_FEE_SCHEDULE (meta-tests on the bundled data)", () => {
+  const ACTIVE_START = 6 * 60; // 06:00
+  const ACTIVE_END = 18 * 60 + 29; // 18:29
+
+  const bandMatchCount = (minuteOfDay: number): number => {
+    let matches = 0;
+    for (const band of REFERENCE_FEE_SCHEDULE) {
+      const from = toMinutes(band.from);
+      const to = toMinutes(band.to);
+      if (minuteOfDay >= from && minuteOfDay <= to) matches++;
+    }
+    return matches;
+  };
+
+  it("covers every minute in 06:00–18:29 with exactly one band", () => {
+    const uncovered: number[] = [];
+    for (let m = ACTIVE_START; m <= ACTIVE_END; m++) {
+      if (bandMatchCount(m) !== 1) uncovered.push(m);
+    }
+    expect(uncovered).toEqual([]);
+  });
+
+  it("covers no minute outside 06:00–18:29", () => {
+    const surprises: number[] = [];
+    for (let m = 0; m < 24 * 60; m++) {
+      if (m >= ACTIVE_START && m <= ACTIVE_END) continue;
+      if (bandMatchCount(m) !== 0) surprises.push(m);
+    }
+    expect(surprises).toEqual([]);
+  });
+
+  it.each([
+    { hour: 6, minute: 0, fee: 8 },
+    { hour: 6, minute: 29, fee: 8 },
+    { hour: 6, minute: 30, fee: 13 },
+    { hour: 7, minute: 0, fee: 18 },
+    { hour: 7, minute: 59, fee: 18 },
+    { hour: 8, minute: 0, fee: 13 },
+    { hour: 8, minute: 30, fee: 8 }, // would be 0 in the buggy Java reference
+    { hour: 12, minute: 0, fee: 8 }, // would be 0 in the buggy Java reference
+    { hour: 14, minute: 29, fee: 8 }, // would be 0 in the buggy Java reference
+    { hour: 15, minute: 0, fee: 13 },
+    { hour: 15, minute: 30, fee: 18 },
+    { hour: 16, minute: 59, fee: 18 },
+    { hour: 17, minute: 0, fee: 13 },
+    { hour: 18, minute: 0, fee: 8 },
+    { hour: 18, minute: 29, fee: 8 },
+    { hour: 18, minute: 30, fee: 0 },
+    { hour: 5, minute: 59, fee: 0 },
+    { hour: 23, minute: 0, fee: 0 },
+  ])("feeAt $hour:$minute → $fee", ({ hour, minute, fee }) => {
+    expect(feeAt(REFERENCE_FEE_SCHEDULE, hour, minute)).toBe(fee);
+  });
+});
+
+const toMinutes = (hhmm: string): number => {
+  const [hh, mm] = hhmm.split(":");
+  if (hh === undefined || mm === undefined) {
+    throw new Error(`Bad band time in test: ${hhmm}`);
+  }
+  return Number(hh) * 60 + Number(mm);
+};

--- a/TypeScript/tests/integration.test.ts
+++ b/TypeScript/tests/integration.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from "vitest";
+import { createTollCalculator, REFERENCE_PRESET } from "../src/index.js";
+import type { Vehicle } from "../src/index.js";
+
+/**
+ * Integration tests — exercise the public API through `createTollCalculator`
+ * configured with the bundled `REFERENCE_PRESET`. These tests prove that
+ * the preset's schedule, holiday calendar, time zone and daily cap are
+ * wired together correctly when consumed as documented.
+ *
+ * Unit tests (see `docs/plan/05-testing-strategy.md`) cover the internals
+ * of each module in isolation. These three tests cover the wiring — each
+ * exercises a distinct path through the calculator.
+ */
+
+describe("integration: createTollCalculator + REFERENCE_PRESET", () => {
+  it("charges 57 across 6 passes on a regular weekday (windowing + multi-band, below cap)", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // Wednesday 2025-09-17, interpreted in REFERENCE_PRESET.timeZone
+    // ("Europe/Stockholm" → CEST = UTC+2 on this date).
+    // Chosen because: no holiday in the reference calendar in September, no
+    // day-before-holiday, DST already settled in spring and not flipping
+    // until late October, and no proximity to Easter (movable).
+    const passes = [
+      new Date("2025-09-17T06:25:00+02:00"), //  8 — band 06:00–06:29
+      new Date("2025-09-17T06:50:00+02:00"), // 13 — same 60-min window as #1
+      new Date("2025-09-17T07:30:00+02:00"), // 18 — new window (Δ from #1 = 65 min)
+      new Date("2025-09-17T12:15:00+02:00"), //  8 — midday off-peak, new window
+      new Date("2025-09-17T16:00:00+02:00"), // 18 — evening rush, new window
+      new Date("2025-09-17T16:45:00+02:00"), // 18 — same window as #5
+    ];
+
+    // Hand-calculation of the windowing algorithm:
+    //   window 1 (anchor 06:25): max(8, 13)   = 13
+    //   window 2 (anchor 07:30): 18           = 18
+    //   window 3 (anchor 12:15): 8            =  8
+    //   window 4 (anchor 16:00): max(18, 18)  = 18
+    //                                   total = 57   (below 60 cap)
+    expect(calc.feeFor(car, passes)).toBe(57);
+  });
+
+  it("returns 0 for a Car on a holiday recognized by the bundled calendar", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // Easter Sunday 2025 is April 20 — a movable feast. Proves the preset's
+    // calendar resolves Easter dynamically (Anonymous Gregorian algorithm),
+    // not via a hard-coded year-specific list.
+    const passes = [
+      new Date("2025-04-20T07:30:00+02:00"), // would be 18 on a weekday
+      new Date("2025-04-20T08:15:00+02:00"), // would be 13 on a weekday
+      new Date("2025-04-20T16:00:00+02:00"), // would be 18 on a weekday
+    ];
+
+    expect(calc.feeFor(car, passes)).toBe(0);
+  });
+
+  it("mixes free hours and paid hours, below the cap", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // A single weekday with passes spread across hours that are both
+    // inside fee bands (paid) and outside them (free — before 06:00,
+    // midday "lull" days off, after 18:29).
+    //
+    //   W1 (anchor 05:00): max(0, 0)   = 0   — pre-band, two passes in window
+    //   W2 (anchor 07:30): max(18, 13) = 18  — peak + same-window 08:00 band
+    //   W3 (anchor 13:00): 8           = 8   — midday band
+    //   W4 (anchor 20:00): 0           = 0   — after 18:29, post-band
+    //                                  ----
+    //                            total = 26  — below the 60 cap
+    const passes = [
+      new Date("2025-09-17T05:00:00+02:00"), //  0  — before 06:00
+      new Date("2025-09-17T05:30:00+02:00"), //  0  — still pre-band, in W1
+      new Date("2025-09-17T07:30:00+02:00"), // 18  — peak, new window
+      new Date("2025-09-17T08:00:00+02:00"), // 13  — same window as 07:30
+      new Date("2025-09-17T13:00:00+02:00"), //  8  — midday off-peak
+      new Date("2025-09-17T20:00:00+02:00"), //  0  — after 18:29
+    ];
+
+    expect(calc.feeFor(car, passes)).toBe(26);
+  });
+
+  it("clamps the total to dailyCap (60 SEK) when the uncapped sum exceeds it", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // Five separate 60-min windows on a single weekday. Each pass lands
+    // in a different window because consecutive passes are 65 min apart,
+    // so the windowing algorithm cannot consolidate them.
+    //
+    //   W1 (anchor 07:00): 18  — peak 07:00–07:59
+    //   W2 (anchor 08:05): 13  — band 08:00–08:29
+    //   W3 (anchor 15:30): 18  — peak 15:30–16:59
+    //   W4 (anchor 16:35): 18  — still inside 15:30–16:59
+    //   W5 (anchor 17:40): 13  — band 17:00–17:59
+    //                     ----
+    //         uncapped:    80   →  clamped to dailyCap = 60
+    const passes = [
+      new Date("2025-09-17T07:00:00+02:00"),
+      new Date("2025-09-17T08:05:00+02:00"),
+      new Date("2025-09-17T15:30:00+02:00"),
+      new Date("2025-09-17T16:35:00+02:00"),
+      new Date("2025-09-17T17:40:00+02:00"),
+    ];
+
+    expect(calc.feeFor(car, passes)).toBe(60);
+  });
+
+  it("returns 0 on a Saturday regardless of time (weekend rule)", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // Saturday 2025-09-13: no public holiday in September, not adjacent to
+    // Easter or any movable feast. Pure weekend rule. Three passes that
+    // would each be a paid band on a weekday must all resolve to 0.
+    const passes = [
+      new Date("2025-09-13T07:30:00+02:00"), // would be 18 on a weekday
+      new Date("2025-09-13T08:15:00+02:00"), // would be 13
+      new Date("2025-09-13T16:00:00+02:00"), // would be 18
+    ];
+
+    expect(calc.feeFor(car, passes)).toBe(0);
+  });
+
+  it("returns 0 on the day before a public holiday (Christmas Eve)", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // Wednesday 2025-12-24 — eve of Christmas Day (Dec 25, a fixed
+    // helgdag per SFS 1989:253 §2). Not one of the three SFS 2004:629
+    // Bilaga 1 carve-outs (Maundy Thursday, Ascension Eve, All Saints'
+    // Eve), so the day-before-holiday rule applies and every pass must
+    // be free. Offset is +01:00 because Stockholm is on CET in December.
+    const passes = [
+      new Date("2025-12-24T07:30:00+01:00"), // would be 18 on a regular weekday
+      new Date("2025-12-24T16:00:00+01:00"), // would be 18
+    ];
+
+    expect(calc.feeFor(car, passes)).toBe(0);
+  });
+
+  it("applies the July clause: first five weekdays taxed, rest of month free", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // SFS 2004:629 Bilaga 1: July is toll-free EXCEPT for the first five
+    // non-Saturday weekdays. In 2025 Jul 1 is a Tuesday, so those five
+    // days are Jul 1, 2, 3, 4 (Tue–Fri) and Jul 7 (Mon, skipping the
+    // Saturday Jul 5). Same wall-clock peak-hour pass on a "taxed" early
+    // weekday vs. a "free" mid-month weekday must resolve to different
+    // fees — the difference proves the carve-out is wired through the
+    // calendar to the calculator.
+    const taxedEarlyJuly = calc.feeFor(car, [
+      new Date("2025-07-03T07:30:00+02:00"), // Thursday, third taxed weekday
+    ]);
+    const freeMidJuly = calc.feeFor(car, [
+      new Date("2025-07-15T07:30:00+02:00"), // Tuesday, past the carve-out
+    ]);
+
+    expect(taxedEarlyJuly).toBe(18);
+    expect(freeMidJuly).toBe(0);
+  });
+
+  it("sorts passes internally regardless of input order", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // Public contract: "Pass order is not significant; the calculator
+    // sorts internally and does not mutate the caller's array." Same
+    // three passes in three different orders must yield the same total.
+    //
+    //   sorted: 06:25 (8) → 06:50 (13) → 07:30 (18)
+    //   W1 (anchor 06:25): max(8, 13) = 13
+    //   W2 (anchor 07:30): 18
+    //                total = 31
+    const a = new Date("2025-09-17T06:25:00+02:00");
+    const b = new Date("2025-09-17T06:50:00+02:00");
+    const c = new Date("2025-09-17T07:30:00+02:00");
+
+    expect(calc.feeFor(car, [a, b, c])).toBe(31);
+    expect(calc.feeFor(car, [c, a, b])).toBe(31);
+    expect(calc.feeFor(car, [c, b, a])).toBe(31);
+  });
+
+  it("interprets wall-clock times in the configured time zone across DST transitions", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // The schedule's bands are wall-clock times in Europe/Stockholm.
+    // Stockholm flips CET (UTC+1) → CEST (UTC+2) on the last Sunday of
+    // March, so the same wall-clock instant has different UTC encodings
+    // across the year. Two passes encoded as UTC `Z` timestamps that
+    // *both* resolve to 07:30 Stockholm wall-clock must both fall in the
+    // 07:00–07:59 = 18 SEK band. If the calculator were using UTC or a
+    // fixed offset, the winter case would land outside the band.
+    //
+    //   Mon 2025-01-13 07:30 Stockholm CET  = 06:30 UTC
+    //   Mon 2025-04-28 07:30 Stockholm CEST = 05:30 UTC
+    const winter = new Date("2025-01-13T06:30:00Z");
+    const summer = new Date("2025-04-28T05:30:00Z");
+
+    expect(calc.feeFor(car, [winter])).toBe(18);
+    expect(calc.feeFor(car, [summer])).toBe(18);
+  });
+
+  it("returns 0 for a Car with no passes (empty input is the identity case)", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    expect(calc.feeFor(car, [])).toBe(0);
+  });
+
+  it("throws TypeError when vehicle is null or undefined", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+
+    expect(() => calc.feeFor(null as unknown as Vehicle, [])).toThrow(
+      TypeError,
+    );
+    expect(() => calc.feeFor(undefined as unknown as Vehicle, [])).toThrow(
+      /is required/,
+    );
+  });
+
+  it("throws TypeError when vehicle is not an object with a `type` property", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+
+    expect(() => calc.feeFor("Car" as unknown as Vehicle, [])).toThrow(
+      /must be an object/,
+    );
+    expect(() => calc.feeFor({} as unknown as Vehicle, [])).toThrow(
+      /must be an object/,
+    );
+  });
+
+  it("throws TypeError when passes is not an array", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    expect(() =>
+      calc.feeFor(car, "not an array" as unknown as readonly Date[]),
+    ).toThrow(/must be an array/);
+  });
+
+  it("throws RangeError when any pass is not a valid Date", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const car: Vehicle = { type: "Car" };
+
+    // new Date("not a date") returns a Date whose getTime() is NaN — TS
+    // types it as Date but it's invalid at runtime.
+    expect(() => calc.feeFor(car, [new Date("not a date")])).toThrow(
+      RangeError,
+    );
+
+    // null inside the array — bypasses TS, real-world JSON.parse output.
+    expect(() =>
+      calc.feeFor(car, [
+        new Date("2025-09-17T07:00:00+02:00"),
+        null as unknown as Date,
+      ]),
+    ).toThrow(/passes\[1\]/);
+
+    // String where a Date is expected — typical post-JSON.parse mistake.
+    expect(() =>
+      calc.feeFor(car, ["2025-09-17T07:00:00+02:00" as unknown as Date]),
+    ).toThrow(/passes\[0\]/);
+  });
+
+  it("returns 0 for a toll-free vehicle regardless of time or date", () => {
+    const calc = createTollCalculator(REFERENCE_PRESET);
+    const motorbike: Vehicle = { type: "Motorbike" };
+
+    // Same passes as the commuter day above — would be 57 for a Car. For a
+    // toll-free vehicle the result must be 0 regardless of times or dates.
+    const passes = [
+      new Date("2025-09-17T06:25:00+02:00"),
+      new Date("2025-09-17T06:50:00+02:00"),
+      new Date("2025-09-17T07:30:00+02:00"),
+      new Date("2025-09-17T12:15:00+02:00"),
+      new Date("2025-09-17T16:00:00+02:00"),
+      new Date("2025-09-17T16:45:00+02:00"),
+    ];
+
+    expect(calc.feeFor(motorbike, passes)).toBe(0);
+  });
+});

--- a/TypeScript/tests/reference-calendar.test.ts
+++ b/TypeScript/tests/reference-calendar.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import { REFERENCE_PRESET } from "../src/presets/reference.js";
+
+/**
+ * The bundled calendar follows SFS 2004:629 (Lag om trängselskatt)
+ * Bilaga 1 and SFS 1989:253 (Lag om allmänna helgdagar). See the
+ * citation block in `src/calendar/swedish.ts`. These tests verify each
+ * rule of the law, including the three day-before-holiday carve-outs
+ * and the July first-five-weekdays carve-out — both areas where the
+ * bundled Java/C# reference at the repo root deviates from the law.
+ */
+
+const cal = REFERENCE_PRESET.calendar;
+
+const stockholmNoon = (year: number, month: number, day: number): Date =>
+  // Noon Stockholm time is unambiguous regardless of DST.
+  new Date(Date.UTC(year, month - 1, day, 10, 0, 0));
+
+/**
+ * Days listed by the Java/C# reference for 2013 that ARE also toll-free
+ * per SFS 2004:629. The three days the Java reference incorrectly marked
+ * free (Maundy Thursday, Ascension Eve, All Saints' Eve) live in their
+ * own describe block below.
+ */
+const LAW_2013_HOLIDAYS: readonly (readonly [number, number])[] = [
+  [1, 1], // Nyårsdagen — public holiday
+  [3, 29], // Långfredagen — Good Friday
+  [4, 1], // Annandag påsk — Easter Monday
+  [4, 30], // Valborgsmässoafton — day before May 1
+  [5, 1], // Första maj — public holiday
+  [5, 9], // Kristi himmelsfärdsdag — Ascension Day
+  [6, 5], // Dag före nationaldagen — day before Jun 6
+  [6, 6], // Sveriges nationaldag — public holiday
+  [6, 21], // Midsommarafton — day before Midsummer Day (Sat Jun 22)
+  [12, 24], // Julafton — day before Christmas Day
+  [12, 25], // Juldagen
+  [12, 26], // Annandag jul
+  [12, 31], // Nyårsafton — day before New Year's Day
+];
+
+describe("Swedish congestion-tax calendar — SFS 2004:629 fidelity (2013)", () => {
+  for (const [month, day] of LAW_2013_HOLIDAYS) {
+    it(`marks 2013-${String(month)}-${String(day)} as toll-free`, () => {
+      expect(cal.isHoliday(stockholmNoon(2013, month, day))).toBe(true);
+    });
+  }
+
+  it("marks every Saturday and Sunday in 2013 as toll-free", () => {
+    let saturdays = 0;
+    let sundays = 0;
+    for (let m = 1; m <= 12; m++) {
+      const daysInMonth = new Date(Date.UTC(2013, m, 0)).getUTCDate();
+      for (let d = 1; d <= daysInMonth; d++) {
+        const dow = new Date(Date.UTC(2013, m - 1, d)).getUTCDay();
+        if (dow === 0 || dow === 6) {
+          expect(cal.isHoliday(stockholmNoon(2013, m, d))).toBe(true);
+          if (dow === 6) saturdays++;
+          else sundays++;
+        }
+      }
+    }
+    expect(saturdays + sundays).toBe(104); // 52 of each in 2013
+  });
+
+  it("does NOT mark ordinary weekdays in 2013 (Feb 5, Mar 12, Sep 17, Oct 22, Nov 26, Dec 17)", () => {
+    const nonHolidays: readonly (readonly [number, number])[] = [
+      [2, 5],
+      [3, 12],
+      [9, 17],
+      [10, 22],
+      [11, 26],
+      [12, 17],
+    ];
+    for (const [month, day] of nonHolidays) {
+      expect(cal.isHoliday(stockholmNoon(2013, month, day))).toBe(false);
+    }
+  });
+});
+
+describe("SFS 2004:629 Bilaga 1 — three day-before-holiday carve-outs are TAXED", () => {
+  // The Java/C# reference flags these as toll-free; the law explicitly
+  // says they ARE charged. We follow the law.
+
+  it("Maundy Thursday (day before Good Friday) is taxed", () => {
+    expect(cal.isHoliday(stockholmNoon(2013, 3, 28))).toBe(false); // Mar 28 2013
+    expect(cal.isHoliday(stockholmNoon(2025, 4, 17))).toBe(false); // Apr 17 2025
+  });
+
+  it("Ascension Eve (day before Ascension Day) is taxed", () => {
+    expect(cal.isHoliday(stockholmNoon(2013, 5, 8))).toBe(false); // May 8 2013
+    expect(cal.isHoliday(stockholmNoon(2025, 5, 28))).toBe(false); // May 28 2025
+  });
+
+  it("All Saints' Eve (Friday before All Saints' Day) is taxed", () => {
+    // 2013: All Saints' Day = Sat Nov 2 → Eve = Fri Nov 1
+    expect(cal.isHoliday(stockholmNoon(2013, 11, 1))).toBe(false);
+    // 2025: All Saints' Day = Sat Nov 1 → Eve = Fri Oct 31
+    expect(cal.isHoliday(stockholmNoon(2025, 10, 31))).toBe(false);
+    // 2027: All Saints' Day = Sat Nov 6 → Eve = Fri Nov 5
+    expect(cal.isHoliday(stockholmNoon(2027, 11, 5))).toBe(false);
+  });
+});
+
+describe("SFS 2004:629 Bilaga 1 — July first-five-weekdays carve-out", () => {
+  it("2013: Jul 1-5 (Mon-Fri) are taxed; Jul 8+ are free", () => {
+    // Jul 1 Mon, 2 Tue, 3 Wed, 4 Thu, 5 Fri — all taxed.
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 1))).toBe(false);
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 2))).toBe(false);
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 3))).toBe(false);
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 4))).toBe(false);
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 5))).toBe(false);
+    // Jul 6, 7 are weekend → free.
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 6))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 7))).toBe(true);
+    // Jul 8 Mon onwards → free.
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 8))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 15))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2013, 7, 31))).toBe(true);
+  });
+
+  it("2025: skips Sat/Sun when counting the first 5 weekdays (Jul 1-4 + Jul 7)", () => {
+    // Jul 1 Tue, 2 Wed, 3 Thu, 4 Fri → taxed (4 of the 5).
+    expect(cal.isHoliday(stockholmNoon(2025, 7, 1))).toBe(false);
+    expect(cal.isHoliday(stockholmNoon(2025, 7, 4))).toBe(false);
+    // Jul 5, 6 weekend.
+    expect(cal.isHoliday(stockholmNoon(2025, 7, 5))).toBe(true);
+    // Jul 7 Mon → taxed (5th).
+    expect(cal.isHoliday(stockholmNoon(2025, 7, 7))).toBe(false);
+    // Jul 8 Tue → free.
+    expect(cal.isHoliday(stockholmNoon(2025, 7, 8))).toBe(true);
+  });
+
+  it("2023: July starts on Saturday — first 5 weekdays are Jul 3-7", () => {
+    // Jul 1 Sat, 2 Sun → weekend (free).
+    expect(cal.isHoliday(stockholmNoon(2023, 7, 1))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2023, 7, 2))).toBe(true);
+    // Jul 3 Mon, 4 Tue, 5 Wed, 6 Thu, 7 Fri → all 5 taxed.
+    expect(cal.isHoliday(stockholmNoon(2023, 7, 3))).toBe(false);
+    expect(cal.isHoliday(stockholmNoon(2023, 7, 7))).toBe(false);
+    // Jul 10 Mon onwards → free.
+    expect(cal.isHoliday(stockholmNoon(2023, 7, 10))).toBe(true);
+  });
+});
+
+describe("Epiphany and its eve (SFS 1989:253 §2 holiday absent from Java reference)", () => {
+  it("Epiphany (Jan 6) is toll-free on every weekday year", () => {
+    // 2025-01-06 Monday → free (new vs Java).
+    expect(cal.isHoliday(stockholmNoon(2025, 1, 6))).toBe(true);
+    // 2026-01-06 Tuesday → free.
+    expect(cal.isHoliday(stockholmNoon(2026, 1, 6))).toBe(true);
+  });
+
+  it("Epiphany Eve (Jan 5) is toll-free via day-before-holiday rule", () => {
+    // 2026-01-05 Monday → free (day before Jan 6 Tuesday holiday).
+    expect(cal.isHoliday(stockholmNoon(2026, 1, 5))).toBe(true);
+    // 2027-01-05 Tuesday → free (day before Jan 6 Wednesday holiday).
+    expect(cal.isHoliday(stockholmNoon(2027, 1, 5))).toBe(true);
+  });
+});
+
+describe("Movable holidays — generalized across years", () => {
+  it("derives Easter Monday correctly across years", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 4, 1))).toBe(true); // 2024 Apr 1
+    expect(cal.isHoliday(stockholmNoon(2025, 4, 21))).toBe(true); // 2025 Apr 21
+  });
+
+  it("derives Good Friday correctly across years", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 3, 29))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2025, 4, 18))).toBe(true);
+  });
+
+  it("derives Ascension Day correctly across years (Easter + 39)", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 5, 9))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2025, 5, 29))).toBe(true);
+  });
+
+  it("derives Midsummer Day (Saturday Jun 20-26) across years", () => {
+    // 2024: Sat 22 Jun is already covered by weekend; also a helgdag.
+    expect(cal.isHoliday(stockholmNoon(2024, 6, 22))).toBe(true);
+    // 2025: Midsummer Day = Sat 21 Jun.
+    expect(cal.isHoliday(stockholmNoon(2025, 6, 21))).toBe(true);
+  });
+
+  it("derives Midsummer Eve (Friday before Midsummer Day) as toll-free", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 6, 21))).toBe(true); // Fri Jun 21
+    expect(cal.isHoliday(stockholmNoon(2025, 6, 20))).toBe(true); // Fri Jun 20
+  });
+
+  it("derives All Saints' Day (Saturday Oct 31-Nov 6) across years", () => {
+    // 2025: All Saints' Day = Sat Nov 1.
+    expect(cal.isHoliday(stockholmNoon(2025, 11, 1))).toBe(true);
+    // 2027: All Saints' Day = Sat Nov 6.
+    expect(cal.isHoliday(stockholmNoon(2027, 11, 6))).toBe(true);
+  });
+});
+
+describe("Day-before-holiday rule — implicit, not hardcoded", () => {
+  it("flags Apr 30 as free across years (day before May 1)", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 4, 30))).toBe(true); // Tue
+    expect(cal.isHoliday(stockholmNoon(2025, 4, 30))).toBe(true); // Wed
+  });
+
+  it("flags Jun 5 as free across years (day before National Day)", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 6, 5))).toBe(true); // Wed
+    expect(cal.isHoliday(stockholmNoon(2025, 6, 5))).toBe(true); // Thu
+  });
+
+  it("flags Dec 24 as free across years (day before Christmas Day)", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 12, 24))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2025, 12, 24))).toBe(true);
+  });
+
+  it("flags Dec 31 as free across years (day before New Year)", () => {
+    expect(cal.isHoliday(stockholmNoon(2024, 12, 31))).toBe(true);
+    expect(cal.isHoliday(stockholmNoon(2025, 12, 31))).toBe(true);
+  });
+
+  it("does NOT flag the day before a day-before-holiday (Dec 23, Apr 29, etc.)", () => {
+    // Dec 24 is free (day before Dec 25), but Dec 23 is just a Tuesday.
+    expect(cal.isHoliday(stockholmNoon(2024, 12, 23))).toBe(false); // Mon
+    expect(cal.isHoliday(stockholmNoon(2025, 12, 23))).toBe(false); // Tue
+    // Apr 30 is free, but Apr 29 is just a Monday/Tuesday.
+    expect(cal.isHoliday(stockholmNoon(2024, 4, 29))).toBe(false); // Mon
+    expect(cal.isHoliday(stockholmNoon(2025, 4, 29))).toBe(false); // Tue
+  });
+
+  it("does NOT generally flag Nov 1 (Java's quirk) when it is not All Saints' Eve", () => {
+    // 2027: All Saints' Day = Sat Nov 6 → Eve = Fri Nov 5.
+    // Nov 1 2027 = Monday — not the eve, not a helgdag, just a weekday.
+    expect(cal.isHoliday(stockholmNoon(2027, 11, 1))).toBe(false);
+  });
+});

--- a/TypeScript/tests/vehicle.test.ts
+++ b/TypeScript/tests/vehicle.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { isTollFreeVehicle } from "../src/vehicle.js";
+import type { Vehicle, VehicleType } from "../src/vehicle.js";
+
+describe("isTollFreeVehicle", () => {
+  it.each<VehicleType>([
+    "Motorbike",
+    "Tractor",
+    "Emergency",
+    "Diplomat",
+    "Foreign",
+    "Military",
+  ])("returns true for %s", (type) => {
+    const vehicle: Vehicle = { type };
+    expect(isTollFreeVehicle(vehicle)).toBe(true);
+  });
+
+  it("returns false for Car (the only chargeable type)", () => {
+    expect(isTollFreeVehicle({ type: "Car" })).toBe(false);
+  });
+});
+
+describe("VehicleType (type-level)", () => {
+  it("is the closed union of the seven documented types", () => {
+    expectTypeOf<VehicleType>().toEqualTypeOf<
+      | "Car"
+      | "Motorbike"
+      | "Tractor"
+      | "Emergency"
+      | "Diplomat"
+      | "Foreign"
+      | "Military"
+    >();
+  });
+});

--- a/TypeScript/tests/zoned-time.test.ts
+++ b/TypeScript/tests/zoned-time.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { parts } from "../src/time/zoned-time.js";
+import { minutesBetween } from "../src/time/diff.js";
+
+describe("parts (wall-clock extraction across IANA zones)", () => {
+  it("maps UTC 04:30 to 06:30 in Europe/Stockholm during summer (CEST = UTC+2)", () => {
+    const result = parts(new Date("2025-09-17T04:30:00Z"), "Europe/Stockholm");
+    expect(result).toEqual({
+      year: 2025,
+      month: 9,
+      day: 17,
+      hour: 6,
+      minute: 30,
+      weekday: 3, // Wednesday (ISO)
+    });
+  });
+
+  it("maps UTC 05:30 to 06:30 in Europe/Stockholm during winter (CET = UTC+1)", () => {
+    const result = parts(new Date("2025-12-10T05:30:00Z"), "Europe/Stockholm");
+    expect(result).toEqual({
+      year: 2025,
+      month: 12,
+      day: 10,
+      hour: 6,
+      minute: 30,
+      weekday: 3, // Wednesday
+    });
+  });
+
+  it("handles DST spring-forward correctly (Europe/Stockholm flips at 01:00 UTC on 2025-03-30)", () => {
+    // 00:59 UTC → still CET (01:59 wall-clock)
+    const before = parts(new Date("2025-03-30T00:59:00Z"), "Europe/Stockholm");
+    expect(before.hour).toBe(1);
+    expect(before.minute).toBe(59);
+
+    // 01:00 UTC → CEST (03:00 wall-clock — the 02:xx hour never happens locally)
+    const after = parts(new Date("2025-03-30T01:00:00Z"), "Europe/Stockholm");
+    expect(after.hour).toBe(3);
+    expect(after.minute).toBe(0);
+  });
+
+  it("handles DST fall-back correctly (Europe/Stockholm flips at 01:00 UTC on 2025-10-26)", () => {
+    // 00:30 UTC → still CEST (02:30 wall-clock)
+    const before = parts(new Date("2025-10-26T00:30:00Z"), "Europe/Stockholm");
+    expect(before.hour).toBe(2);
+    expect(before.minute).toBe(30);
+
+    // 01:30 UTC → CET (02:30 wall-clock — same wall time, but 1 hour later in UTC)
+    const after = parts(new Date("2025-10-26T01:30:00Z"), "Europe/Stockholm");
+    expect(after.hour).toBe(2);
+    expect(after.minute).toBe(30);
+  });
+
+  it("returns the same instant with different wall-clocks across zones", () => {
+    const instant = new Date("2025-09-17T14:45:00Z");
+
+    expect(parts(instant, "Europe/Stockholm")).toMatchObject({
+      hour: 16,
+      minute: 45,
+    });
+    expect(parts(instant, "America/New_York")).toMatchObject({
+      hour: 10,
+      minute: 45,
+    });
+    expect(parts(instant, "Asia/Tokyo")).toMatchObject({
+      hour: 23,
+      minute: 45,
+    });
+  });
+
+  it("derives ISO weekday correctly across the week", () => {
+    const zone = "Europe/Stockholm";
+    // 2025-09-15 is a Monday in Stockholm.
+    expect(parts(new Date("2025-09-15T10:00:00Z"), zone).weekday).toBe(1);
+    expect(parts(new Date("2025-09-16T10:00:00Z"), zone).weekday).toBe(2);
+    expect(parts(new Date("2025-09-17T10:00:00Z"), zone).weekday).toBe(3);
+    expect(parts(new Date("2025-09-18T10:00:00Z"), zone).weekday).toBe(4);
+    expect(parts(new Date("2025-09-19T10:00:00Z"), zone).weekday).toBe(5);
+    expect(parts(new Date("2025-09-20T10:00:00Z"), zone).weekday).toBe(6);
+    expect(parts(new Date("2025-09-21T10:00:00Z"), zone).weekday).toBe(7);
+  });
+
+  it("returns 1-12 month numbering, not 0-11", () => {
+    // January
+    expect(
+      parts(new Date("2025-01-15T12:00:00Z"), "Europe/Stockholm").month,
+    ).toBe(1);
+    // December
+    expect(
+      parts(new Date("2025-12-15T12:00:00Z"), "Europe/Stockholm").month,
+    ).toBe(12);
+  });
+
+  it("rejects invalid IANA zone with a clear error", () => {
+    expect(() =>
+      parts(new Date("2025-09-17T12:00:00Z"), "Europe/Stockholmo"),
+    ).toThrow(RangeError);
+    expect(() =>
+      parts(new Date("2025-09-17T12:00:00Z"), "Mars/Olympus_Mons"),
+    ).toThrow(RangeError);
+  });
+});
+
+describe("minutesBetween (UTC ms diff in minutes)", () => {
+  it("returns 0 for the same instant", () => {
+    const t = new Date("2025-09-17T12:00:00Z");
+    expect(minutesBetween(t, t)).toBe(0);
+  });
+
+  it("returns the positive difference when later > earlier", () => {
+    const a = new Date("2025-09-17T12:00:00Z");
+    const b = new Date("2025-09-17T13:30:00Z");
+    expect(minutesBetween(a, b)).toBe(90);
+  });
+
+  it("returns the negative difference when later < earlier", () => {
+    const a = new Date("2025-09-17T13:30:00Z");
+    const b = new Date("2025-09-17T12:00:00Z");
+    expect(minutesBetween(a, b)).toBe(-90);
+  });
+
+  it("returns fractional minutes for sub-minute differences", () => {
+    const a = new Date("2025-09-17T12:00:00.000Z");
+    const b = new Date("2025-09-17T12:00:30.000Z");
+    expect(minutesBetween(a, b)).toBe(0.5);
+  });
+
+  it("is unaffected by DST — measures UTC duration, not wall-clock duration", () => {
+    // Two passes 60 UTC-minutes apart across the spring-forward transition.
+    // Wall clock moves 2 hours (00:59 CET → 03:00 CEST), but UTC moves 1 hour.
+    // The 60-minute window rule must see 60, not 120.
+    const before = new Date("2025-03-30T00:30:00Z");
+    const after = new Date("2025-03-30T01:30:00Z");
+    expect(minutesBetween(before, after)).toBe(60);
+  });
+});

--- a/TypeScript/tsconfig.json
+++ b/TypeScript/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src", "tests", "vitest.config.ts", "eslint.config.js"]
+}

--- a/TypeScript/vitest.config.ts
+++ b/TypeScript/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/index.ts"],
+      thresholds: {
+        lines: 90,
+        statements: 90,
+        functions: 90,
+        branches: 90,
+        "src/calculator.ts": {
+          lines: 100,
+          statements: 100,
+          functions: 100,
+          branches: 100,
+        },
+        "src/fee-schedule.ts": {
+          lines: 100,
+          statements: 100,
+          functions: 100,
+          branches: 100,
+        },
+      },
+    },
+  },
+});

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+# Dynamic, agent-maintained working document.
+# Regenerated/updated at the end of each task to reflect the current
+# punch list — intentionally not versioned. See HARNESS.md.
+follow-ups.md

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -1,0 +1,210 @@
+# Harness — context-first AI collaboration in this repo
+
+> Adapted from Walking Labs' [Harness Engineering][harness] framework.
+> The harness is the methodology that produced the implementation plan
+> and the code; it survives across modules and would apply identically
+> to the next library this candidate writes. The module-specific plan
+> lives in [`plan/`](plan/).
+
+## What this document is
+
+A reusable description of **how the human + AI collaborate on this
+codebase**: the context layers, the briefing template, what is and is
+not delegated, the anti-patterns avoided, the harness components that
+live in this repo, and the operating rules followed during sessions.
+
+If you remove every line of TypeScript from this repo and start a
+different module tomorrow, this document still applies. The
+implementation plan in [`plan/`](plan/) does not.
+
+---
+
+## 1. Why a harness
+
+The interview emphasised that the way I use AI matters. The honest
+answer is that I do not type prompts directly into a code-generation
+model and accept what comes out — the gap between "looks right" and
+"is right" is too large. Instead I **invest heavily in context** before
+asking the AI to produce anything: design docs, discovery findings,
+testing strategy, explicit phase deliverables. The AI is a junior with
+infinite patience and zero memory; my job is to brief it well, verify
+its outputs, and own every decision.
+
+That practice has a name: **harness engineering** — designing the
+working environment so the AI's behaviour is constrained by explicit
+artifacts, not by hope. The `docs/` folder *is* that harness. A
+reviewer can see exactly what the AI was told before any code was
+written.
+
+[harness]: https://walkinglabs.github.io/learn-harness-engineering/en/
+
+---
+
+## 2. The three layers of context I use
+
+1. **Project context** — `docs/discovery/` and `docs/plan/`. Stable
+   across sessions, version-controlled, English.
+2. **Session context** — the conversation with the AI, scoped to one
+   phase from `plan/06-implementation-phases.md`. Short sessions, one
+   phase at a time.
+3. **Working context** — the open file in the editor, the failing
+   test, the exact error message. Always pasted verbatim.
+
+If any of these three is missing, I do not type a prompt.
+
+---
+
+## 3. How I brief the AI per phase
+
+Per phase, the prompt to the AI follows this template:
+
+```
+We are in phase N of docs/plan/06-implementation-phases.md.
+Read docs/plan/04-domain-model.md §X.Y for the exact API.
+Read docs/discovery/04-bugs.md §Z for what must NOT happen.
+Write src/<file>.ts. No extra exports. No premature abstraction.
+Then write tests/<file>.test.ts covering the cases in
+docs/plan/05-testing-strategy.md §X.
+Run `pnpm check`. If anything fails, do not patch the test — fix
+the code.
+```
+
+---
+
+## 4. What I will NOT delegate to the AI
+
+- **Naming.** I pick the names. The AI can suggest, I decide.
+- **Public API shape.** Frozen in `plan/04-domain-model.md` before any
+  code is written.
+- **Test cases.** I write the table; the AI fills the rows.
+- **Architectural decisions.** Already made in `plan/`.
+
+---
+
+## 5. What I will delegate to the AI
+
+- Implementing the body of a function whose signature and tests
+  already exist.
+- Translating a `plan/` §X.Y into a first-draft file.
+- Drafting commit messages and PR bodies from the diff.
+- Generating boilerplate (eslint config, tsconfig, CI yaml) from a
+  verbal spec.
+
+---
+
+## 6. Anti-patterns I avoid
+
+- Letting the AI "decide" the architecture by writing the first file
+  from a one-line prompt.
+- Asking the AI to "review" code it just wrote — the second pass adds
+  nothing.
+- Long, meandering chat sessions. I close the session when the phase
+  is done.
+- Pasting the whole codebase into the prompt. Phase-scoped context
+  only.
+
+---
+
+## 7. Harness components in this project
+
+Mapping the harness-engineering concepts to concrete artifacts in this
+repo. Each row is a portable concept paired with the artifact that
+implements it here.
+
+| Harness concept                    | Artifact in this repo                                                                                                                                              |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Repository as system of record** | Every architectural decision, legal citation, and tradeoff lives in `docs/`. Conversation history is ephemeral; only what is committed survives.                   |
+| **Feature lists as primitives**    | `plan/06-implementation-phases.md` decomposes the work into seven enumerated phases, each with an explicit deliverable and a `pnpm check` gate.                    |
+| **Initialization phase separate from execution** | `docs/discovery/` and `docs/plan/` exist before the first source file. The AI is never asked to write code without first being briefed via these files.            |
+| **Victory conditions**             | Two layers: (a) `pnpm check` green locally and in CI; (b) every rule citing a primary source has its citation fetched and verified before commit.                  |
+| **Verification inside the harness** | `vitest.config.ts` enforces ≥ 90 % global and 100 % `calculator.ts`/`fee-schedule.ts` coverage. ESLint flat config with `strictTypeChecked`. Prettier as format gate. |
+| **One brief is not enough**        | The plan is ten files under `plan/`, each scoped to one concern. A single mega-README would be unreadable and untrustable.                                         |
+| **Clean state at session end**     | No `wip` commits, no orphan branches, no skipped tests left in place. The dynamic punch list at `docs/follow-ups.md` (gitignored, agent-maintained) is rewritten at task end so the next session reads it first and picks up cold.  |
+| **Observability**                  | `pnpm test:coverage` produces a per-file coverage report; CI uploads the artifact. Test output is the primary signal.                                              |
+
+---
+
+## 8. Operating rules I apply when working with the AI
+
+Stated as portable instructions so they transfer to other projects.
+The evidence that each rule was applied here lives in the git history
+and in the docs themselves.
+
+1. **Brief before generating.** No prompt-to-produce-code until the
+   relevant `plan/` section is loaded into the model's context.
+   *Reason:* the AI is excellent at executing a brief, mediocre at
+   inventing one.
+
+2. **Never accept a suppression as a fix.** If a linter, type-checker
+   or test points at a conflict, the answer is realignment, not
+   silencing. `eslint-disable`, `@ts-ignore`, and `xfail` are smells.
+   *Reason:* the tool detected a real misalignment; hiding the signal
+   leaves the misalignment in the code.
+
+3. **Verify primary sources before committing citations.** Anything
+   quoted in JSDoc (a law, an RFC, a spec) is fetched and pasted
+   verbatim, not paraphrased from the model's training data.
+   *Reason:* model citations can be plausible but wrong; the cost of
+   one `WebFetch` is far less than the cost of a wrong-cited rule
+   compounding across a year of operations.
+
+4. **The AI proposes; the human picks the name.** Identifiers, file
+   names, and public-API shapes are decided by the human. The AI
+   offers options, not verdicts.
+   *Reason:* naming sets vocabulary for everyone downstream; it
+   deserves one human's judgment.
+
+5. **Doc-and-code drift is a bug, not a footnote.** When the code
+   evolves, the relevant `plan/` section is updated in the same PR.
+   *Reason:* a future maintainer who reads outdated docs is worse off
+   than one who has no docs.
+
+6. **Commits are records, not diaries.** Each commit's body answers
+   the questions a future `git log --grep` is asking: what changed,
+   why, what bug it kills, where the citation lives. Iteration noise
+   is squashed out.
+   *Reason:* `git log` is consulted by both humans and LLMs; the cost
+   of writing a good commit body is paid once, the cost of a bad one
+   compounds.
+
+7. **One brief, many phases.** Each phase of work gets a fresh session
+   scoped to the relevant plan files only. The plan is the long-term
+   memory; the conversation is short-term.
+   *Reason:* long meandering chats produce long meandering code.
+
+8. **Reject "good enough" when the law is one fetch away.** If a rule
+   is encoded in a public document (legal text, spec, vendor docs),
+   the implementation cites the document — not the closest hand-coded
+   approximation.
+   *Reason:* the next year's data will reveal which approximations
+   were wrong; the documented rule will not.
+
+---
+
+## 9. Why this matters for the assignment
+
+The interview asked how I use AI. The answer in this folder is
+concrete:
+
+- No vibe-coding. Every file has a stated purpose before it is
+  created.
+- No "trust me" — the plan is in source control alongside the code.
+- The discovery folder shows the AI was given **adversarial input**
+  (the broken reference) and asked to enumerate the failure modes
+  *before* writing a replacement.
+- The plan folder shows that the design exists on paper before any
+  line of TypeScript is written.
+
+If a junior engineer was asked to take over the project tomorrow,
+they would read these documents in order and be productive in an
+hour. That is the test.
+
+---
+
+## 10. Reference
+
+- Walking Labs — *Harness Engineering*: <https://walkinglabs.github.io/learn-harness-engineering/en/>
+- This repo's plan: [`plan/`](plan/)
+- This repo's discovery (analysis of the reference Java/C#): [`discovery/`](discovery/)
+- Dynamic agent log (gitignored, regenerated each session):
+  [`follow-ups.md`](follow-ups.md)

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -3,7 +3,8 @@
 > Adapted from Walking Labs' [Harness Engineering][harness] framework.
 > The harness is the methodology that produced the implementation plan
 > and the code; it survives across modules and would apply identically
-> to the next library this candidate writes. The module-specific plan
+> to any other library produced under this harness. The module-specific
+> plan
 > lives in [`plan/`](plan/).
 
 ## What this document is
@@ -21,7 +22,7 @@ implementation plan in [`plan/`](plan/) does not.
 
 ## 1. Why a harness
 
-The interview emphasised that the way I use AI matters. The honest
+The brief emphasised that the way I use AI matters. The honest
 answer is that I do not type prompts directly into a code-generation
 model and accept what comes out — the gap between "looks right" and
 "is right" is too large. Instead I **invest heavily in context** before
@@ -181,9 +182,9 @@ and in the docs themselves.
 
 ---
 
-## 9. Why this matters for the assignment
+## 9. Why this matters
 
-The interview asked how I use AI. The answer in this folder is
+The brief asked how I use AI. The answer in this folder is
 concrete:
 
 - No vibe-coding. Every file has a stated purpose before it is

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ The repository is the deliverable for a hiring conversation for an
 **AI engineer role**. The brief specified:
 
 - **TypeScript** as the target language.
-- Code that is **proud-to-ship-to-production**, not just "passes the test".
+- **Production-grade code**.
 - **Quality through tests** (unit and integration).
 - **AI-augmented development** with a strong focus on *context*, aligned
   with the [harness engineering](https://walkinglabs.github.io/learn-harness-engineering/en/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# `toll-calculator` — documentation
+
+This folder is organised in three layers, listed in order of decreasing
+generality. A reader can stop at any level and have a coherent picture.
+
+## [`HARNESS.md`](HARNESS.md) — methodology (cross-module)
+
+The context-first AI-collaboration methodology that produced this
+repo. Components, operating rules, what is and is not delegated. This
+file would apply identically to the next module the candidate writes.
+
+## [`discovery/`](discovery/) — analysis of the reference code
+
+Static analysis of the C# / Java reference shipped at the repository
+root: project overview, business rules, bugs (`D§4.1`–`D§4.8`), code
+smells, and a high-level recommendation for a rewrite.
+
+## [`plan/`](plan/) — implementation plan for THIS module
+
+Concrete plan for the TypeScript library that the PR delivers. Covers
+the context behind the assignment, tech-stack decisions, architecture,
+domain model, testing strategy, implementation phases, delivery, and
+the CI / GitHub Actions layer.
+
+## [`follow-ups.md`](follow-ups.md) — dynamic agent log (gitignored)
+
+Working punch list maintained by the agent across sessions. Rewritten
+at the end of each task so the next session can recover context cold.
+Intentionally not versioned — see [`.gitignore`](.gitignore) and the
+rationale in [`HARNESS.md`](HARNESS.md) §7.
+
+---
+
+## Context
+
+This work is a take-home assignment for an **AI engineer role** at a
+consultancy client. The interview emphasized:
+
+- **TypeScript** as the target language.
+- Code that is **proud-to-ship-to-production** — not just "passes the test".
+- **Quality through tests** (unit and integration).
+- **AI-augmented development** with a strong focus on *context*, aligned with
+  the [harness engineering](https://walkinglabs.github.io/learn-harness-engineering/en/)
+  approach.
+
+The candidate has one week (from the interview date) to deliver a PR.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@ generality. A reader can stop at any level and have a coherent picture.
 
 The context-first AI-collaboration methodology that produced this
 repo. Components, operating rules, what is and is not delegated. This
-file would apply identically to the next module the candidate writes.
+file would apply identically to any other module produced under this
+harness.
 
 ## [`discovery/`](discovery/) — analysis of the reference code
 
@@ -18,7 +19,7 @@ smells, and a high-level recommendation for a rewrite.
 ## [`plan/`](plan/) — implementation plan for THIS module
 
 Concrete plan for the TypeScript library that the PR delivers. Covers
-the context behind the assignment, tech-stack decisions, architecture,
+the context behind the deliverable, tech-stack decisions, architecture,
 domain model, testing strategy, implementation phases, delivery, and
 the CI / GitHub Actions layer.
 
@@ -33,14 +34,14 @@ rationale in [`HARNESS.md`](HARNESS.md) §7.
 
 ## Context
 
-This work is a take-home assignment for an **AI engineer role** at a
-consultancy client. The interview emphasized:
+The repository is the deliverable for a hiring conversation for an
+**AI engineer role**. The brief specified:
 
 - **TypeScript** as the target language.
-- Code that is **proud-to-ship-to-production** — not just "passes the test".
+- Code that is **proud-to-ship-to-production**, not just "passes the test".
 - **Quality through tests** (unit and integration).
-- **AI-augmented development** with a strong focus on *context*, aligned with
-  the [harness engineering](https://walkinglabs.github.io/learn-harness-engineering/en/)
+- **AI-augmented development** with a strong focus on *context*, aligned
+  with the [harness engineering](https://walkinglabs.github.io/learn-harness-engineering/en/)
   approach.
 
-The candidate has one week (from the interview date) to deliver a PR.
+Timeline: one week from brief to PR delivery.

--- a/docs/discovery/01-project-overview.md
+++ b/docs/discovery/01-project-overview.md
@@ -1,0 +1,36 @@
+# 1. Project overview
+
+This repository is a **technical assessment exercise** (code kata / take-home)
+for an interview. The `README.md` describes an urban toll-fee calculator
+for an unnamed city. The only locale signal in the assignment statement
+is the currency: **fees in SEK**. The reference Java / C# code hard-codes
+a 2013-specific holiday list whose dates match Swedish public holidays
+(though the code never names a country or city).
+
+## What the candidate must deliver
+
+The candidate is expected to deliver an implementation — in the language of
+their choice — via a fork + pull request. The existing C# and Java code is
+provided as a **deliberately flawed reference**: the README hints at this
+explicitly ("the last city-developer quit, claiming this solution is
+production-ready").
+
+## What the exercise really measures
+
+This is not a clean starting base — it is a **critical-reading test**. The
+interviewer is looking for the candidate's ability to:
+
+- Detect the bugs that are obviously planted in the code.
+- Restate the business rules in a clean implementation.
+- Add tests that would have caught the bugs.
+- Justify design decisions in the PR description.
+
+## Headline numbers
+
+| Metric                | Value                                    |
+| --------------------- | ---------------------------------------- |
+| Source files          | 9 (`.java` + `.cs`)                      |
+| Lines of useful code  | ~210                                     |
+| Test files            | 0                                        |
+| Build files           | 0 (no `pom.xml`, `.csproj`, `Makefile`)  |
+| Functional bugs found | At least 6 (see [04-bugs.md](04-bugs.md))|

--- a/docs/discovery/01-project-overview.md
+++ b/docs/discovery/01-project-overview.md
@@ -1,24 +1,23 @@
 # 1. Project overview
 
-This repository is a **technical assessment exercise** (code kata / take-home)
-for an interview. The `README.md` describes an urban toll-fee calculator
-for an unnamed city. The only locale signal in the assignment statement
-is the currency: **fees in SEK**. The reference Java / C# code hard-codes
-a 2013-specific holiday list whose dates match Swedish public holidays
-(though the code never names a country or city).
+This repository is a small **coding exercise**: an urban toll-fee
+calculator for an unnamed city. The only locale signal in the brief
+is the currency — **fees in SEK**. The reference Java / C# code
+hard-codes a 2013-specific holiday list whose dates match Swedish
+public holidays (though the code never names a country or city).
 
-## What the candidate must deliver
+## What the deliverable is
 
-The candidate is expected to deliver an implementation — in the language of
-their choice — via a fork + pull request. The existing C# and Java code is
-provided as a **deliberately flawed reference**: the README hints at this
-explicitly ("the last city-developer quit, claiming this solution is
+A working implementation — in the language of choice — delivered via
+fork + pull request. The existing C# and Java code is provided as a
+**deliberately flawed reference**: the README hints at this explicitly
+("the last city-developer quit, claiming this solution is
 production-ready").
 
 ## What the exercise really measures
 
-This is not a clean starting base — it is a **critical-reading test**. The
-interviewer is looking for the candidate's ability to:
+This is not a clean starting base — it is a **critical-reading
+exercise**. The reviewer is looking for the ability to:
 
 - Detect the bugs that are obviously planted in the code.
 - Restate the business rules in a clean implementation.

--- a/docs/discovery/02-structure.md
+++ b/docs/discovery/02-structure.md
@@ -1,0 +1,36 @@
+# 2. Structure and layout
+
+```
+toll-calculator/
+├── README.md          # assignment + gif
+├── C#/                # C# reference implementation
+│   ├── TollCalculator.cs
+│   ├── Vehicle.cs     (interface)
+│   ├── Car.cs
+│   ├── Motorbike.cs
+│   └── LICENSE
+└── Java/              # same design in Java
+    ├── TollCalculator.java
+    ├── Vehicle.java   (interface)
+    ├── Car.java
+    └── Motorbike.java
+```
+
+## Observations
+
+- **Parallel implementations.** The Java and C# folders are near 1:1
+  translations of each other. The two versions diverge in one critical place
+  (the time-diff calculation — see [04-bugs.md](04-bugs.md) §4.1) and that
+  divergence is itself a bug.
+- **No build configuration.** No Maven/Gradle file for Java, no `.csproj` /
+  `.sln` for C#. The project does not compile out of the box without manual
+  setup.
+- **No tests.** No `src/test`, no `*Tests.cs`, no test runner config.
+- **No `.gitignore`.** Any `bin/`, `obj/`, or `*.class` artifacts would be
+  versioned by accident.
+- **License.** Only the C# folder contains a `LICENSE` file; the Java folder
+  does not.
+- **Domain model.** A `Vehicle` interface with `Car` and `Motorbike` as
+  concrete classes. Other vehicle types referenced by name (`Tractor`,
+  `Emergency`, `Diplomat`, `Foreign`, `Military`) are mentioned only as
+  string literals in the toll-free enum — there are no classes for them.

--- a/docs/discovery/02-structure.md
+++ b/docs/discovery/02-structure.md
@@ -2,7 +2,7 @@
 
 ```
 toll-calculator/
-├── README.md          # assignment + gif
+├── README.md          # brief + gif
 ├── C#/                # C# reference implementation
 │   ├── TollCalculator.cs
 │   ├── Vehicle.cs     (interface)

--- a/docs/discovery/03-business-rules.md
+++ b/docs/discovery/03-business-rules.md
@@ -1,0 +1,49 @@
+# 3. Business rules
+
+Rules as declared in `README.md`:
+
+| Rule                      | Detail                                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------- |
+| Fee range                 | Between **8 and 18 SEK**, depending on the time of day                                  |
+| Rush hour                 | Renders the highest fee (18 SEK)                                                        |
+| Daily cap                 | **60 SEK** maximum per day                                                              |
+| Hourly window             | A vehicle is charged **at most once per hour**; the highest fee in the window applies   |
+| Vehicle exemptions        | Some vehicle types are toll-free                                                        |
+| Date exemptions           | Weekends and holidays are toll-free                                                     |
+
+## Fee table inferred from the source
+
+Reconstructed from the `if`/`else` chain in `TollCalculator.java:55-64` and
+`TollCalculator.cs:62-71`:
+
+| Time window     | Fee (SEK) |
+| --------------- | --------- |
+| 06:00 – 06:29   | 8         |
+| 06:30 – 06:59   | 13        |
+| 07:00 – 07:59   | 18        |
+| 08:00 – 08:29   | 13        |
+| 08:30 – 14:59   | 8         |
+| 15:00 – 15:29   | 13        |
+| 15:30 – 16:59   | 18        |
+| 17:00 – 17:59   | 13        |
+| 18:00 – 18:29   | 8         |
+| Everything else | 0         |
+
+> **Important:** The implementation does **not** match this table — see
+> [04-bugs.md](04-bugs.md) §4.3.
+
+## Toll-free vehicle types
+
+- Motorbike
+- Tractor
+- Emergency
+- Diplomat
+- Foreign
+- Military
+
+## Toll-free dates (hard-coded for 2013 only)
+
+Jan 1; Mar 28–29; Apr 1, 30; May 1, 8, 9; Jun 5, 6, 21; the whole of July;
+Nov 1; Dec 24, 25, 26, 31; plus every Saturday and Sunday.
+
+The 2013-only scope is itself a defect — see [04-bugs.md](04-bugs.md) §4.6.

--- a/docs/discovery/04-bugs.md
+++ b/docs/discovery/04-bugs.md
@@ -1,0 +1,151 @@
+# 4. Bugs detected
+
+Each bug is referenced by file and line number for direct navigation.
+
+---
+
+## 4.1 CRITICAL — Time diff calculation in C# is broken
+
+**Location:** `C#/TollCalculator.cs:25-26`
+
+```csharp
+long diffInMillies = date.Millisecond - intervalStart.Millisecond;
+long minutes = diffInMillies/1000/60;
+```
+
+`DateTime.Millisecond` returns **only the millisecond component (0–999)**, not
+the epoch timestamp. The subtraction can never exceed ±999 ms, so `minutes`
+is **always 0**, and the "once per hour" rule **never triggers correctly** —
+the code always falls into the `minutes <= 60` branch.
+
+**Fix:** use `(date - intervalStart).TotalMinutes`.
+
+**Note:** The Java version (`Java/TollCalculator.java:22-23`) uses
+`date.getTime()` correctly. The bug exists only in C#.
+
+---
+
+## 4.2 BUG — `intervalStart` is never advanced
+
+**Location:** `Java/TollCalculator.java:15-32`, `C#/TollCalculator.cs:18-38`
+
+`intervalStart` is set to `dates[0]` once and **never reassigned**. This means
+the "one-hour window" is always measured against the **first pass of the
+day**, not the last billed pass. For a day with passes at 06:15, 07:30, and
+09:00, every comparison is against 06:15 — the logic is completely skewed.
+
+**Fix:** when `minutes > 60`, set `intervalStart = date` to start a new window.
+
+---
+
+## 4.3 BUG — Fee table conditions are broken
+
+**Location:** `Java/TollCalculator.java:59`, `C#/TollCalculator.cs:66`
+
+```java
+else if (hour >= 8 && hour <= 14 && minute >= 30 && minute <= 59) return 8;
+```
+
+This forgets the **00–29 minute slots of hours 9–14**, falling through to
+`return 0`. So a pass at 10:15 — which should cost 8 SEK — is billed as free.
+
+**Location:** `Java/TollCalculator.java:61`, `C#/TollCalculator.cs:68`
+
+```java
+else if (hour == 15 && minute >= 0 || hour == 16 && minute <= 59) return 18;
+```
+
+Operator precedence parses this as
+`(hour == 15 && minute >= 0) || (hour == 16 && minute <= 59)`. The `15:xx`
+side overlaps with the previous branch (already returned 13 for 15:00–15:29)
+and is unreachable. The intent was almost certainly
+`(hour == 15 && minute >= 30) || hour == 16`.
+
+---
+
+## 4.4 BUG — No defensive handling for `dates`
+
+**Location:** `Java/TollCalculator.java:15`, `C#/TollCalculator.cs:18`
+
+If `dates` is empty, `dates[0]` throws `ArrayIndexOutOfBoundsException` /
+`IndexOutOfRangeException`. If `dates` is not sorted chronologically, the
+algorithm produces meaningless results. There is no null check, no empty
+check, no sort.
+
+---
+
+## 4.5 BUG — Totals can go negative
+
+**Location:** `Java/TollCalculator.java:26`, `C#/TollCalculator.cs:30`
+
+```java
+if (totalFee > 0) totalFee -= tempFee;
+```
+
+When `tempFee > totalFee` (e.g. the first pass of the day was expensive and a
+later window contains a different combination), `totalFee` becomes negative.
+The `> 0` guard is insufficient — it should clamp:
+`totalFee = Math.max(0, totalFee - tempFee)`.
+
+---
+
+## 4.6 BUG — Holiday calendar hard-coded to year 2013
+
+**Location:** `Java/TollCalculator.java:77`, `C#/TollCalculator.cs:82`
+
+```java
+if (year == 2013) { ... }
+```
+
+The reference's `isTollFreeDate` only knows the toll-free days for year
+2013. For any other year, **Easter, Pentecost, Midsummer, and every
+other movable feast are billed as normal days**.
+
+The list is also a flat enumeration of specific calendar dates —
+including eve-of-holiday entries such as Apr 30, Jun 5, Nov 1, Dec 24,
+Dec 31 as individual hard-coded entries rather than derived from any
+rule. So even if the `year == 2013` guard were lifted, there is no
+algorithm underneath to generalize.
+
+**Fix direction:** drop the year guard and compute toll-free days from
+a general rule for any Gregorian year. The concrete rule set — which
+holidays apply, which eves are taxed, the special July clause — is a
+question about Swedish law that this implementation answers in the
+plan, not here.
+
+---
+
+## 4.7 BUG — Vehicle exemption by stringly-typed comparison
+
+**Location:** `Java/TollCalculator.java:37-46`, `C#/TollCalculator.cs:43-53`
+
+```java
+vehicleType.equals(TollFreeVehicles.MOTORBIKE.getType())
+```
+
+The exemption list compares the `Vehicle.getType()` return value (a `String`)
+against enum-derived strings. Any typo in a new subclass (e.g. `"motorbike"`
+in lowercase) silently breaks the exemption without any compile-time signal.
+
+**Fix:** make "toll-free" a property of the `Vehicle` (e.g.
+`vehicle.isTollFree()`) or model the vehicle type as a typed enum.
+
+---
+
+## 4.8 BUG — Public `getTollFee(Date, Vehicle)` bypasses the daily logic
+
+**Location:** `Java/TollCalculator.java:48`, `C#/TollCalculator.cs:55`
+
+The single-pass overload is `public`. Callers can invoke it directly and
+completely skip the once-per-hour and 60-SEK-cap rules. It should be
+`private`.
+
+---
+
+## 4.9 Combined effect
+
+Bugs 4.1, 4.2, and 4.5 interact: the daily cap of 60 SEK happens to clamp the
+output, which means the function "looks right" on the happy path but the
+intermediate totals are wrong, and certain inputs produce **negative fees**
+or **uncapped windows**. A trivial unit test on a multi-pass day would have
+exposed all three.

--- a/docs/discovery/05-code-smells.md
+++ b/docs/discovery/05-code-smells.md
@@ -50,4 +50,4 @@ correctness across edge cases.
   per-language, but no `.editorconfig`).
 - **README mixes languages and tone.** Includes a giphy link and an ironic
   "production-ready" claim — intentional for the exercise, but not something
-  to mirror in the candidate's submission.
+  to mirror in the deliverable.

--- a/docs/discovery/05-code-smells.md
+++ b/docs/discovery/05-code-smells.md
@@ -1,0 +1,53 @@
+# 5. Code smells and minor issues
+
+These are not functional bugs, but they harm readability, extensibility, or
+correctness across edge cases.
+
+## Java
+
+- **Legacy date API.** Uses `java.util.Date` + `Calendar` instead of
+  `java.time.*` (which has been the recommended API since Java 8).
+- **Useless import.** `java.util.concurrent.*` is imported only for
+  `TimeUnit`, which is itself unnecessary — `Duration.between(...)` would be
+  cleaner.
+- **Boxed `Boolean` return.** `private Boolean isTollFreeDate(...)` returns
+  the wrapper instead of the primitive `boolean` — risks accidental NPE.
+- **No package declaration.** Files live in the default package.
+- **Mutable `Date`.** `java.util.Date` is mutable, which makes the
+  `Date... dates` varargs caller-vulnerable.
+
+## C#
+
+- **No timezone awareness.** Uses `DateTime` without zone info; any
+  rush-hour-based toll system needs explicit time-zone handling so that
+  fees are computed against wall-clock times in the operator's zone and
+  DST transitions are not silently mis-billed — `DateTimeOffset` or
+  explicit `TimeZoneInfo` use is required.
+- **Namespace coupling is fragile.** `Vehicle.cs` declares
+  `namespace TollFeeCalculator`, but `TollCalculator.cs` is **outside** any
+  namespace and imports it via `using`. Inconsistent.
+- **Useless `using` directives.** `Car.cs` and `Vehicle.cs` import
+  `System.Linq`, `System.Threading.Tasks`, etc. — nothing is used.
+- **Enum used for string compare.** `TollFreeVehicles` is an `enum` whose
+  string name is compared via `.ToString()` — same stringly-typed problem as
+  the Java version.
+
+## Both
+
+- **No tests.** A single happy-path unit test would have caught most of the
+  bugs in [04-bugs.md](04-bugs.md).
+- **No `.gitignore`.** Build artifacts would be versioned by accident.
+- **Public single-pass overload.** See bug §4.8.
+- **No input validation.** `null`, empty list, unsorted list — all undefined
+  behavior.
+- **Stringly-typed vehicle exemption.** See bug §4.7.
+- **Hard-coded constants.** Fees (8, 13, 18), cap (60), the 2013 holiday set
+  are all magic numbers inlined in the calculator — no configuration
+  boundary.
+- **Calculator owns too much.** `TollCalculator` is both the fee table, the
+  holiday calendar, and the windowing logic. These should be split.
+- **Inconsistent indentation.** Two spaces in Java, four in C# (acceptable
+  per-language, but no `.editorconfig`).
+- **README mixes languages and tone.** Includes a giphy link and an ironic
+  "production-ready" claim — intentional for the exercise, but not something
+  to mirror in the candidate's submission.

--- a/docs/discovery/06-recommendations.md
+++ b/docs/discovery/06-recommendations.md
@@ -1,0 +1,96 @@
+# 7. Reimplementation recommendations
+
+The reference code is not worth patching. A clean rewrite is faster and
+shows more clearly what the candidate understands. The recommendations below
+are language-agnostic.
+
+## 6.1 Domain model
+
+```
+Pass        { vehicle, timestamp }
+Vehicle     { type, isTollFree }
+FeeSchedule { ranges: [(from, to, fee)] }
+HolidayCalendar { isHoliday(date) }
+TollCalculator(schedule, calendar, dailyCap)
+    .feeFor(vehicle, passes: List[DateTime]) -> int
+```
+
+- Make "toll-free" a **property of the vehicle**, not a string lookup. Bug
+  §4.7 disappears.
+- Inject the holiday calendar. Bug §4.6 disappears, and the system becomes
+  testable for any year.
+- Inject the fee schedule. The fee table moves from `if`/`else` to data; bug
+  §4.3 disappears and the code becomes table-driven.
+
+## 6.2 Algorithm (correct version of the windowing logic)
+
+```
+fee_for(vehicle, passes):
+    if vehicle.is_toll_free: return 0
+    if not passes: return 0
+
+    passes = sorted(passes)
+    total = 0
+    window_start = passes[0]
+    window_max   = fee_at(window_start)
+
+    for p in passes[1:]:
+        if (p - window_start) <= 1 hour:
+            window_max = max(window_max, fee_at(p))
+        else:
+            total += window_max
+            window_start = p
+            window_max   = fee_at(p)
+
+    total += window_max
+    return min(total, DAILY_CAP)
+```
+
+This handles bugs §4.2 (window restart), §4.5 (no negative totals), §4.4
+(empty input), and the daily cap in a single pass.
+
+## 6.3 Time handling
+
+- **Java:** use `java.time.LocalDateTime` / `ZonedDateTime` with
+  `ZoneId.of("Europe/Stockholm")` and `Duration.between(a, b).toMinutes()`.
+- **C#:** use `DateTimeOffset` and `TimeZoneInfo.FindSystemTimeZoneById(...)`
+  or NodaTime.
+- Never subtract `DateTime.Millisecond` — see bug §4.1.
+
+## 6.4 Holiday calendar
+
+The reference enumerates a flat list of dates for year 2013. To
+generalize, the rewrite needs:
+- A `HolidayCalendar` abstraction injected into the calculator, so any
+  year and any jurisdiction can be plugged in.
+- A computed Easter date (the **Anonymous Gregorian algorithm** is the
+  standard choice), since most movable Swedish holidays derive from it.
+- A concrete calendar implementation that reproduces the toll-free
+  days the reference encodes for 2013 and extends to other years —
+  the actual rule set is a separate investigation handled in the plan.
+
+## 6.5 Tests to include
+
+At minimum, parametrized tests covering:
+
+1. Single pass at each fee tier (8, 13, 18, free).
+2. Multiple passes within the same hour — highest applies.
+3. Multiple passes across hour boundaries — each charged separately.
+4. Daily total exceeding 60 SEK — capped at 60.
+5. Toll-free vehicle on a fee-time pass.
+6. Toll-free date (Saturday, Sunday, holiday).
+7. Empty pass list.
+8. Unordered pass list.
+9. Boundary minutes: 06:00, 06:29, 06:30, 18:29, 18:30.
+10. DST transition day (Europe/Stockholm flips in late March / late October).
+
+## 6.6 Recommended language choice
+
+Per the README, the candidate may pick freely. Practical picks:
+
+- **Kotlin / Python:** fastest to write, easiest test ergonomics.
+- **Go:** tidy, no dependencies, builtin testing.
+- **TypeScript:** good for showing typed domain modelling.
+
+Whichever you pick, keep the public API to ~3 functions and let the tests be
+the documentation.

--- a/docs/discovery/06-recommendations.md
+++ b/docs/discovery/06-recommendations.md
@@ -1,8 +1,8 @@
-# 7. Reimplementation recommendations
+# 6. Reimplementation recommendations
 
 The reference code is not worth patching. A clean rewrite is faster and
-shows more clearly what the candidate understands. The recommendations below
-are language-agnostic.
+shows the design intent more clearly. The recommendations below are
+language-agnostic.
 
 ## 6.1 Domain model
 
@@ -86,7 +86,7 @@ At minimum, parametrized tests covering:
 
 ## 6.6 Recommended language choice
 
-Per the README, the candidate may pick freely. Practical picks:
+Per the README, the language is open. Practical picks:
 
 - **Kotlin / Python:** fastest to write, easiest test ergonomics.
 - **Go:** tidy, no dependencies, builtin testing.

--- a/docs/discovery/07-delivery-checklist.md
+++ b/docs/discovery/07-delivery-checklist.md
@@ -1,0 +1,53 @@
+# 8. Delivery checklist
+
+A practical checklist for submitting the take-home.
+
+## Before writing code
+
+- [ ] Re-read `README.md` end-to-end.
+- [ ] Confirm the fee table from [03-business-rules.md](03-business-rules.md).
+- [ ] Decide language and stick with it.
+- [ ] Decide whether to translate the reference code (do not) or rewrite from
+      the README (do).
+
+## Code
+
+- [ ] Domain model: `Vehicle`, `Pass`, `FeeSchedule`, `HolidayCalendar`,
+      `TollCalculator`.
+- [ ] Vehicle exemption is a property of the vehicle, not a string lookup.
+- [ ] Fee table is data, not a chain of `if`/`else`.
+- [ ] Holiday calendar is injectable; supports any year.
+- [ ] Time arithmetic uses the modern date/time API of your language with a
+      timezone.
+- [ ] Windowing logic restarts `window_start` correctly.
+- [ ] Daily cap of 60 SEK applied at the end via `min`.
+- [ ] No negative totals possible.
+- [ ] Empty / null / unsorted input handled defensively.
+
+## Tests
+
+- [ ] At least the 10 scenarios listed in
+      [07-recommendations.md](07-recommendations.md) §7.5.
+- [ ] Tests pass locally with one command.
+- [ ] Coverage report optional but appreciated.
+
+## Repo hygiene
+
+- [ ] `.gitignore` appropriate for the chosen language.
+- [ ] Build/run instructions in your `README.md`.
+- [ ] No build artifacts committed.
+- [ ] One feature per commit, meaningful messages.
+
+## PR description
+
+In the PR, explicitly list:
+
+1. The bugs you found in the reference code (link to lines).
+2. The design decisions you made (why a strategy/table for fees, why a
+   separate calendar, etc.).
+3. How to run the tests.
+4. Assumptions you made where the README is silent (e.g. timezone, behavior
+   on empty input, treatment of the day before a holiday).
+
+That last point is what most candidates skip — and what the interviewer is
+specifically looking for.

--- a/docs/discovery/07-delivery-checklist.md
+++ b/docs/discovery/07-delivery-checklist.md
@@ -1,6 +1,6 @@
-# 8. Delivery checklist
+# 7. Delivery checklist
 
-A practical checklist for submitting the take-home.
+A practical checklist before delivering the PR.
 
 ## Before writing code
 
@@ -27,7 +27,7 @@ A practical checklist for submitting the take-home.
 ## Tests
 
 - [ ] At least the 10 scenarios listed in
-      [07-recommendations.md](07-recommendations.md) §7.5.
+      [06-recommendations.md](06-recommendations.md) §6.5.
 - [ ] Tests pass locally with one command.
 - [ ] Coverage report optional but appreciated.
 
@@ -49,5 +49,5 @@ In the PR, explicitly list:
 4. Assumptions you made where the README is silent (e.g. timezone, behavior
    on empty input, treatment of the day before a holiday).
 
-That last point is what most candidates skip — and what the interviewer is
-specifically looking for.
+That last point is what most submissions skip — and the one the
+reviewer is specifically looking for.

--- a/docs/discovery/README.md
+++ b/docs/discovery/README.md
@@ -1,7 +1,7 @@
 # Discovery — initial findings
 
 Static analysis of the reference C# / Java code that ships with the repo.
-This stage is **only about understanding the input**: what the assignment
+This stage is **only about understanding the input**: what the brief
 asks, what the reference code does (and does wrong), and what the rewrite
 should preserve or change.
 

--- a/docs/discovery/README.md
+++ b/docs/discovery/README.md
@@ -1,0 +1,20 @@
+# Discovery — initial findings
+
+Static analysis of the reference C# / Java code that ships with the repo.
+This stage is **only about understanding the input**: what the assignment
+asks, what the reference code does (and does wrong), and what the rewrite
+should preserve or change.
+
+## Index
+
+1. [Project overview](01-project-overview.md)
+2. [Structure and layout](02-structure.md)
+3. [Business rules (extracted from README)](03-business-rules.md)
+4. [Bugs detected](04-bugs.md)
+5. [Code smells and minor issues](05-code-smells.md)
+6. [Reimplementation recommendations](06-recommendations.md)
+7. [Delivery checklist](07-delivery-checklist.md)
+
+> The actual implementation plan lives in [`../plan/`](../plan/).
+
+> Analysis date: 2026-05-22 · Branch: `master` @ `d856630`

--- a/docs/plan/01-context-and-goals.md
+++ b/docs/plan/01-context-and-goals.md
@@ -1,0 +1,62 @@
+# 1. Context and goals
+
+## 1.1 How I got here
+
+- The deliverable is for a hiring conversation for an **AI engineer
+  role** at a consultancy client.
+- A scoping call with the hiring manager set the brief.
+- I have **one week** from that call to deliver the PR.
+- Successful delivery leads to a follow-up code-discussion session.
+
+## 1.2 What the brief told me to optimize for
+
+From the scoping call:
+
+1. **TypeScript.** The whole call orbited TypeScript — that is the
+   target language for the deliverable.
+2. **Proud-to-ship-to-prod.** The brief was explicit: *"something you'd be
+   proud to send to production"*. The test is not "make it pass" — it is
+   "show how you build software".
+3. **Tests are part of the deliverable.** I said in the call that I use unit
+   and integration tests to lock down quality; I now have to back that up.
+4. **AI usage is part of the deliverable.** I said I lean on the
+   [harness engineering](https://walkinglabs.github.io/learn-harness-engineering/en/)
+   philosophy — context first, AI second. This `docs/` folder is part of
+   that demonstration: the AI was given clean context before any code was
+   written.
+
+## 1.3 Definition of done
+
+The deliverable is "done" when the following are all true:
+
+- [ ] All business rules from the README produce correct results.
+- [ ] All bugs documented in `[D§4]` are absent in the new implementation.
+- [ ] Unit tests cover every fee tier, every exemption, every edge case.
+- [ ] At least one integration test exercises the public API end-to-end.
+- [ ] CI runs lint + type-check + tests on every push.
+- [ ] `README.md` (root) explains how to install, test, and use the library
+      in under 60 seconds of reading.
+- [ ] The PR description lists the bugs found, the design decisions made,
+      and the assumptions taken where the original README is silent.
+- [ ] Repo has a clean `.gitignore` and zero build artifacts committed.
+- [ ] `npm test` is the only command a reviewer needs to validate the work.
+
+## 1.4 Non-goals
+
+- A web UI, REST API, persistence layer, or backend framework
+  (Nest / Express / Fastify). The deliverable is a plain Node library.
+- Bundling more than one preset. The library is designed so that new
+  jurisdictions are a single new file under `presets/` — but I only ship
+  the reference preset derived from the Java / C# code in this repo.
+- Supporting languages other than TypeScript.
+- Translating the original C# / Java code line-for-line.
+
+## 1.5 Constraints I am imposing on myself
+
+- **No premature abstraction.** The code must not look like a framework. A
+  toll calculator does not need a plugin system.
+- **No mocks of the SUT.** Tests exercise real code paths; only the clock /
+  holiday calendar are injectable, and the test doubles for those are
+  trivial.
+- **No dependencies I cannot justify in a sentence.** Each entry in
+  `package.json` must earn its place.

--- a/docs/plan/02-tech-stack.md
+++ b/docs/plan/02-tech-stack.md
@@ -1,0 +1,189 @@
+# 2. Tech stack
+
+Every choice here is justified in one line. If I cannot defend the choice in
+a sentence, it does not go in.
+
+## 2.0 Shape of the deliverable
+
+A plain Node/TypeScript library — no HTTP server, no framework (Nest / Express /
+Fastify), no CLI. The reference code is a class; the TS equivalent is a typed function.
+
+## 2.1 Runtime and language
+
+| Tool          | Choice                | Why                                                                         |
+| ------------- | --------------------- | --------------------------------------------------------------------------- |
+| Language      | **TypeScript 6.x**    | The brief was explicit: TypeScript. Using the latest stable line.           |
+| Runtime       | **Node.js 20 LTS**    | Current LTS; safe default for an enterprise reviewer.                       |
+| Module system | **ESM** (`"type": "module"`) | Modern default; no surprises with `import`/`export`.                  |
+| Package mgr   | **pnpm 10** (via corepack) | Faster installs, content-addressed store, strict peer deps. Corepack ships with Node 20+, so the reviewer needs no global install — `corepack enable && pnpm install` is the whole setup. |
+
+## 2.2 TypeScript configuration
+
+`tsconfig.json` highlights:
+
+- `"strict": true`
+- `"noUncheckedIndexedAccess": true` — would have caught bug `[D§4.4]`
+- `"exactOptionalPropertyTypes": true`
+- `"verbatimModuleSyntax": true` — forces explicit `import type` / `export type`
+- `"target": "ES2022"`, `"module": "NodeNext"`, `"moduleResolution": "NodeNext"`
+- `"declaration": true`, `"sourceMap": true`
+
+## 2.2.1 TypeScript coding conventions
+
+A handful of style decisions that are enforced by the type-checker and / or
+ESLint, recorded here so they can be defended in review.
+
+### Function members in interfaces — property syntax, never method shorthand
+
+```ts
+// ✅ used everywhere
+interface HolidayCalendar {
+  readonly isHoliday: (date: Date) => boolean;
+}
+
+// ❌ never used
+interface HolidayCalendar {
+  isHoliday(date: Date): boolean;
+}
+```
+
+Reasons:
+
+1. **Stricter parameter checking.** With `strictFunctionTypes` (on by
+   default in `strict` mode), property-style function types are checked
+   **contravariantly**; method shorthand is checked **bivariantly** — a
+   deliberate soundness hole TypeScript keeps for ergonomics with
+   `Array.prototype` methods. Property syntax catches bugs the method
+   form lets through.
+2. **`readonly` works.** A `readonly` property cannot be reassigned;
+   method shorthand has no equivalent modifier. Marking every callable
+   `readonly` is consistent with the library's immutability stance.
+3. **No-classes house style.** The implementation uses factory functions
+   returning object literals (`createSwedishCongestionTaxCalendar(): HolidayCalendar`),
+   never classes with methods. Property syntax matches that — method
+   shorthand suggests OOP class methods.
+4. **Lint-enforced.** `@typescript-eslint/method-signature-style` is on
+   via the `stylisticTypeChecked` preset and defaults to `"property"`.
+
+### `interface` vs `type` — interface for object shapes, type for everything else
+
+| Shape                         | Tool          |
+| ----------------------------- | ------------- |
+| Object / function-as-property | `interface`   |
+| String-literal union          | `type`        |
+| Array / tuple                 | `type`        |
+| Mapped / conditional          | `type`        |
+
+Rationale: `interface` is slightly more ergonomic for consumers who want
+to `extends` a public API shape, and has marginal compiler caching
+benefits on large types. For unions, arrays and other non-object shapes,
+`interface` is not expressible — `type` is required. This is a mechanical
+rule, not a paradigm statement: the codebase is functional (no `class`,
+no inheritance), and `interface` here describes structural shapes only.
+
+### Immutability — `readonly` on every member of every public shape
+
+Every interface in the public surface uses `readonly` on every member.
+The library does not mutate inputs and does not expect callers to mutate
+outputs; `readonly` makes that contract type-level rather than verbal.
+
+### Array types — `readonly T[]`, not `ReadonlyArray<T>`
+
+Both forms are semantically identical. `readonly T[]` is the lint default
+(`@typescript-eslint/array-type`) and reads shorter at call sites.
+
+## 2.3 Testing
+
+| Tool      | Choice          | Why                                                                             |
+| --------- | --------------- | ------------------------------------------------------------------------------- |
+| Runner    | **Vitest**      | Fast, ESM-native, Jest-compatible API, no Babel needed.                         |
+| Assertion | **vitest** built-in | One dep is better than two.                                                 |
+| Coverage  | **`@vitest/coverage-v8`** | Native v8 coverage, no instrumentation overhead.                       |
+| Property  | **`fast-check`** (optional) | Property-based tests for the windowing algorithm — see plan §5.3.    |
+
+## 2.4 Quality gates
+
+| Tool          | Choice               | Why                                                              |
+| ------------- | -------------------- | ---------------------------------------------------------------- |
+| Linter        | **ESLint** w/ `@typescript-eslint` | Catches what the type-checker doesn't.            |
+| Formatter     | **Prettier**         | Removes style debates from the PR review.                        |
+| Type-check    | **`tsc --noEmit`**   | Final correctness gate.                                          |
+| Git hooks     | None / **husky** optional | Only add if it doesn't slow down `npm test`.                |
+
+## 2.5 Date and time
+
+### Decision: **`@js-temporal/polyfill`** for zone arithmetic
+
+The library's only runtime dependency. The public API still accepts the
+platform `Date` (so consumers don't have to import anything to use us);
+internally we convert to `Temporal.Instant` to extract wall-clock parts
+in a specific IANA zone.
+
+| Layer                                 | Tool                              |
+| ------------------------------------- | --------------------------------- |
+| Input type from consumers             | `Date` (platform-native)          |
+| `feeFor` 60-min-window arithmetic     | `Date.getTime()` ms subtraction   |
+| Wall-clock extraction in a zone       | `Temporal.Instant.toZonedDateTimeISO(zone)` (via polyfill) |
+| Future-proofing                       | Polyfill drops out when V8 ships Temporal natively — the call sites are spec-final |
+
+### Why a library at all (and not native `Intl.DateTimeFormat`)
+
+`Date` has no method that answers *"what wall clock does this instant
+produce in city X?"*. The closest native option is
+`Intl.DateTimeFormat`, but it is a **string-formatting** API — using it
+for arithmetic means:
+
+- Calling `formatToParts()` to get `{type, value}` tuples.
+- Parsing string values back to numbers.
+- Working around the `"24"` quirk of `hour12: false` in older engines.
+- Deriving weekday manually because the formatted weekday string is
+  locale-sensitive.
+- Caching formatter instances (expensive to construct) yourself.
+
+That works (a ~60-line wrapper does the job) but is a known rabbit hole
+in code review. A dedicated library exposes the arithmetic directly.
+
+### Alternatives considered
+
+Evaluated before committing to Temporal:
+
+| Library                           | Size       | Weekly downloads (2026) | Verdict      | Reason                                                                                                              |
+| --------------------------------- | ---------- | ----------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **`@js-temporal/polyfill`**       | ~50 KB     | ~1.5 M                  | ✅ **chosen** | TC39 Stage 3 spec; will be native in V8 within 1–2 years; cleanest API; explicit DST-ambiguity handling.            |
+| **Luxon**                         | ~75 KB     | ~30 M                   | runner-up    | Most battle-tested; same author lineage as moment.js; chosen if "max reviewer familiarity" outweighs future-proof.  |
+| **`dayjs` + utc + timezone**      | ~7 KB + plugins | ~25 M             | rejected     | Smallest, but plugin-based timezone support is awkward; moment-style mutable-feel API.                              |
+| **`date-fns-tz`**                 | ~30 KB     | ~7 M                    | rejected     | Functional + tree-shakable, but two packages (`date-fns` + `date-fns-tz`) for what one should do.                   |
+| **`moment-timezone`**             | ~70 KB     | ~7 M (declining)        | rejected     | In maintenance mode; project itself recommends migration away.                                                      |
+| **Native `Intl.DateTimeFormat`**  | 0 KB       | n/a                     | rejected     | Zero runtime deps but ~60 lines of glue code that becomes a review rabbit hole; doesn't help on DST ambiguity.      |
+
+### Defense if challenged
+
+- *"Why not Luxon, which has 20× more downloads?"* — Luxon is the safer
+  conservative choice. Temporal is what the language is converging to;
+  picking it now means our call sites become spec-final the moment V8
+  ships it (Firefox 139 already does). The polyfill version follows the
+  spec exactly; future code change is just dropping the import.
+- *"Why a library at all?"* — see the rabbit-hole list above. The
+  ~60-line `Intl.DateTimeFormat` wrapper works but invites questions
+  about locale handling, DST ambiguity, formatter caching, and the
+  `"24"` quirk. A dedicated time library answers all of those by design.
+- *"Why a polyfill of an unfinished spec?"* — Temporal is Stage 3, which
+  means the API is finalized in shape; only minor edge-case adjustments
+  happen now. Risk is low; the polyfill tracks the spec.
+
+## 2.6 CI
+
+| Tool                 | Choice                                                |
+| -------------------- | ----------------------------------------------------- |
+| **GitHub Actions**   | Native to where the PR will live.                     |
+| Matrix               | Node 20 only — single supported runtime.              |
+| Jobs                 | `lint`, `typecheck`, `test` (with coverage artifact). |
+
+## 2.7 Dependency budget
+
+Production deps: **1** (`@js-temporal/polyfill`). Justified in §2.5.
+
+Dev deps: ~9 — `typescript`, `vitest`, `@vitest/coverage-v8`,
+`@fast-check/vitest`, `fast-check`, `eslint`, `@eslint/js`,
+`typescript-eslint`, `prettier`, `@types/node`. Anything else needs
+justification in the PR.

--- a/docs/plan/03-architecture.md
+++ b/docs/plan/03-architecture.md
@@ -1,0 +1,167 @@
+# 3. Architecture
+
+The library is small enough that "architecture" is mostly **where the
+boundaries are**. The non-negotiable boundaries are:
+
+- The **fee schedule** is data, not a chain of `if`/`else` — kills `[D§4.3]`.
+- The **holiday calendar** is injectable — kills `[D§4.6]`.
+- The **vehicle exemption** is a property of the vehicle, not a string
+  comparison — kills `[D§4.7]`.
+- The **time zone** is an explicit option, not inferred from the runtime
+  — kills `[D§4.1]`.
+
+## 3.1 Module layout
+
+```
+TypeScript/
+├── src/
+│   ├── index.ts                # public barrel — the only consumer entry point
+│   ├── calculator.ts           # createTollCalculator + the public types
+│   ├── vehicle.ts              # Vehicle / VehicleType / isTollFreeVehicle
+│   ├── fee-schedule.ts         # FeeBand / FeeSchedule / feeAt
+│   ├── calendar/
+│   │   ├── index.ts            # HolidayCalendar interface
+│   │   ├── combine.ts          # combineCalendars helper
+│   │   ├── easter.ts           # Gauss's algorithm
+│   │   └── swedish.ts          # createSwedishCongestionTaxCalendar — SFS 2004:629 + SFS 1989:253
+│   ├── presets/
+│   │   └── reference.ts        # REFERENCE_PRESET + REFERENCE_FEE_SCHEDULE (wires swedish.ts in)
+│   └── time/
+│       ├── zoned-time.ts       # IANA-zone-aware hour/minute/weekday helpers
+│       └── diff.ts             # millisecond -> minute helpers
+├── tests/
+│   ├── integration.test.ts
+│   ├── calculator.test.ts
+│   ├── vehicle.test.ts
+│   ├── fee-schedule.test.ts
+│   ├── easter.test.ts
+│   ├── reference-calendar.test.ts
+│   ├── combine-calendars.test.ts
+│   └── zoned-time.test.ts
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── eslint.config.js
+└── README.md
+```
+
+The repo-root `Java/` and `C#/` folders stay in place — they are the
+reference fixture; removing them would lose context for the reviewer.
+
+## 3.2 Dependency direction
+
+```
+index.ts (barrel)
+  ├── calculator.ts
+  │     ├── vehicle.ts
+  │     ├── fee-schedule.ts
+  │     └── calendar/index.ts        (interface only)
+  ├── calendar/combine.ts ── depends on ── calendar/index.ts
+  └── presets/reference.ts
+        ├── calendar/index.ts
+        ├── calendar/easter.ts
+        ├── fee-schedule.ts
+        ├── calculator.ts            (for TollCalculatorPreset type)
+        └── time/zoned-time.ts
+```
+
+- `calculator.ts` knows nothing about any specific jurisdiction — it talks
+  to the `HolidayCalendar` interface and the `FeeSchedule` data shape.
+  Everything jurisdiction-specific lives in `presets/`.
+- A new jurisdiction adds a new file under `presets/` and changes nothing
+  else.
+
+## 3.3 Pure core, thin shell
+
+- `calculator.ts` is **pure**: no clock, no globals, no I/O. Given the
+  same inputs, it returns the same output.
+- The only mutable state in the system is whatever the caller chooses to
+  hold — the library does not own any.
+
+## 3.4 No classes
+
+The implementation does not use `class`. Holiday calendars are factory
+functions that return object literals satisfying `HolidayCalendar`. The
+calculator is the same. This matches the convention in plan §2.2.1
+(property-syntax callables, no `this` semantics, no inheritance).
+
+## 3.5 Error policy
+
+### Two contracts, one entry point
+
+The public method `feeFor` enforces **two contracts** simultaneously:
+
+1. **Compile-time contract** — the TypeScript signature.
+   `feeFor(vehicle: Vehicle, passes: readonly Date[]) => number` rejects
+   `null`, `undefined`, or non-`Date` inputs at the type level for any
+   caller compiled through `tsc`. In-process TypeScript code cannot
+   misuse the API.
+
+2. **Runtime contract** — boundary validation in
+   [`src/validation.ts`](../../TypeScript/src/validation.ts).
+   TypeScript guarantees evaporate when input crosses a non-TS boundary:
+   `JSON.parse` from an HTTP response, a row from an under-typed ORM, a
+   plain-JS consumer, anything traversing `as any`. At runtime the
+   function executes against whatever shape the caller actually passed.
+
+The runtime layer is implemented as assertion functions
+(`assertVehicle`, `assertPasses`) that take `unknown` and use TypeScript's
+`asserts value is X` narrowing. Two consequences:
+
+- ESLint's `no-unnecessary-condition` rule is satisfied **without
+  suppressing it**: the checks happen against `unknown`, which legitimately
+  includes `null`, `undefined`, strings, and so on.
+- The public signature stays strict (`Vehicle`, not `Vehicle | null`), so
+  honest TypeScript callers pay no ergonomic cost.
+
+### Behavior
+
+| Input                                       | Outcome                                                 |
+| ------------------------------------------- | ------------------------------------------------------- |
+| `vehicle` is `null` or `undefined`          | `TypeError("feeFor: \`vehicle\` is required …")`        |
+| `vehicle` is not an object with a `type` property | `TypeError("feeFor: \`vehicle\` must be an object …")` |
+| `passes` is not an array                    | `TypeError("feeFor: \`passes\` must be an array")`      |
+| Any element of `passes` is not a valid `Date` (incl. `Date` with `NaN` time, `null`, `undefined`, a string) | `RangeError("feeFor: passes[i] is not a valid Date")` (with the index `i` of the offending element) |
+| Empty `passes` array                        | Returns `0` (identity case, not an error)              |
+| Unsorted `passes`                           | Sorted internally; the caller's array is **not** mutated |
+
+Validation runs **once**, at the first lines of `feeFor`. After it
+returns, the rest of the function works with narrowed, trusted types —
+internal helpers never see malformed input.
+
+### Defense if challenged
+
+> *"Why validate at runtime when TypeScript already guarantees the
+> shapes?"* — Because the realistic source of bad input is exactly the
+> place where TypeScript stopped helping: a remote API returning strings
+> instead of timestamps, an ORM row whose nullability lied, a JS caller
+> bypassing types entirely. A clear `TypeError` at the boundary turns
+> hours of stack-trace archaeology into one line of "ah, my upstream
+> contract changed".
+
+Errors are thrown, not returned. The library is small enough that a
+`Result`-style API would be ceremony without benefit, and the boundary
+validation catches the cases where `Result` would shine (untrusted
+input) at the cost of one assertion call per entry.
+
+## 3.6 Public surface
+
+```ts
+export type { Vehicle, VehicleType } from "./vehicle.js";
+export type { FeeBand, FeeSchedule } from "./fee-schedule.js";
+export type { HolidayCalendar } from "./calendar/index.js";
+export { combineCalendars } from "./calendar/combine.js";
+export type {
+  TollCalculatorOptions,
+  TollCalculatorPreset,
+  TollCalculator,
+} from "./calculator.js";
+export { createTollCalculator } from "./calculator.js";
+export {
+  REFERENCE_PRESET,
+  REFERENCE_FEE_SCHEDULE,
+} from "./presets/reference.js";
+```
+
+Full per-module details and rationale are in
+[`04-domain-model.md`](04-domain-model.md).

--- a/docs/plan/04-domain-model.md
+++ b/docs/plan/04-domain-model.md
@@ -1,0 +1,307 @@
+# 4. Domain model and API
+
+The public surface is intentionally small. The library exposes:
+
+- A pure factory `createTollCalculator(options)` that produces a calculator.
+- A typed `TollCalculatorOptions` shape that callers fill in.
+- A `TollCalculatorPreset` — a named, ready-to-use options bundle.
+- One bundled preset (`REFERENCE_PRESET`) that mirrors the data baked into
+  the original Java / C# reference code.
+- A `combineCalendars` helper for composing holiday calendars without
+  re-implementing the union logic.
+- Plain types for `Vehicle`, `FeeBand`, `FeeSchedule`, `HolidayCalendar`.
+
+Every callable is declared as a `readonly` property with an arrow function
+type — see plan §2.2.1 for the rationale.
+
+## 4.1 Vehicle
+
+```ts
+// vehicle.ts
+export type VehicleType =
+  | "Car"
+  | "Motorbike"
+  | "Tractor"
+  | "Emergency"
+  | "Diplomat"
+  | "Foreign"
+  | "Military";
+
+export interface Vehicle {
+  readonly type: VehicleType;
+}
+
+const TOLL_FREE_TYPES = new Set<VehicleType>([
+  "Motorbike",
+  "Tractor",
+  "Emergency",
+  "Diplomat",
+  "Foreign",
+  "Military",
+]);
+
+export const isTollFreeVehicle = (v: Vehicle): boolean =>
+  TOLL_FREE_TYPES.has(v.type);
+```
+
+`VehicleType` is a **string literal union**, not an enum. Three reasons:
+
+1. Cheap interop — callers can write `{ type: "Car" }` without importing.
+2. Exhaustiveness via `never` in `switch` blocks.
+3. TypeScript enums emit runtime objects; we do not need that.
+
+Killing bug `[D§4.7]`: exemption is a `Set` lookup, not a chain of string
+equality checks.
+
+## 4.2 Fee schedule
+
+```ts
+// fee-schedule.ts
+export interface FeeBand {
+  /** Inclusive lower bound as "HH:MM". */
+  readonly from: string;
+  /** Inclusive upper bound as "HH:MM". */
+  readonly to: string;
+  /** Fee in the schedule's currency. */
+  readonly fee: number;
+}
+
+export type FeeSchedule = readonly FeeBand[];
+```
+
+The default data lives next to the preset:
+
+```ts
+// presets/reference.ts
+export const REFERENCE_FEE_SCHEDULE: FeeSchedule = [
+  { from: "06:00", to: "06:29", fee: 8 },
+  { from: "06:30", to: "06:59", fee: 13 },
+  { from: "07:00", to: "07:59", fee: 18 },
+  { from: "08:00", to: "08:29", fee: 13 },
+  { from: "08:30", to: "14:59", fee: 8 },
+  { from: "15:00", to: "15:29", fee: 13 },
+  { from: "15:30", to: "16:59", fee: 18 },
+  { from: "17:00", to: "17:59", fee: 13 },
+  { from: "18:00", to: "18:29", fee: 8 },
+];
+```
+
+A `feeAt(schedule, hour, minute)` helper lives in `fee-schedule.ts`:
+
+```ts
+export const feeAt = (
+  schedule: FeeSchedule,
+  hour: number,
+  minute: number,
+): number => {
+  const m = hour * 60 + minute;
+  for (const band of schedule) {
+    const [fh, fm] = band.from.split(":").map(Number);
+    const [th, tm] = band.to.split(":").map(Number);
+    if (m >= fh * 60 + fm && m <= th * 60 + tm) return band.fee;
+  }
+  return 0;
+};
+```
+
+Killing bug `[D§4.3]`: the fee table is data, and `feeAt` covers every
+minute of the day by definition (any minute not inside a band returns 0).
+
+A schedule-validation test will assert there are **no overlaps** and **no
+gaps inside 06:00–18:29** — meta-tests on the data.
+
+## 4.3 Holiday calendar
+
+```ts
+// calendar/index.ts
+export interface HolidayCalendar {
+  readonly isHoliday: (date: Date) => boolean;
+}
+```
+
+The default implementation is a **factory function**, not a class — to
+match the no-classes house style. It lives in `src/calendar/swedish.ts`
+and is wired into the preset via `src/presets/reference.ts`.
+
+> Full primary-source ledger — verbatim Swedish excerpts, divergences
+> from the Java reference's 2013 list, and the mapping from each
+> statute clause to a line in `swedish.ts` — lives in
+> [`legal-references.md`](legal-references.md).
+
+The factory derives every toll-free day from primary Swedish
+legislation, not from a hard-coded list:
+
+- **SFS 2004:629** (Lag om trängselskatt), Bilaga 1 — the law that
+  governs Stockholm's congestion tax. Source:
+  https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-2004629-om-trangselskatt_sfs-2004-629/
+- **SFS 1989:253** (Lag om allmänna helgdagar), §2 — the enumeration of
+  *helgdagar* the previous law refers to. Source:
+  https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/
+
+The algorithm (verbatim from `src/calendar/swedish.ts`):
+
+```ts
+const isHoliday = (date: Date): boolean => {
+  const p = parts(date, "Europe/Stockholm");
+  // 1. Weekend.
+  if (p.weekday >= 6) return true;
+  // 2. Public holiday per SFS 1989:253 §2.
+  if (isPublicHoliday(p.year, p.month, p.day)) return true;
+  // 3. July: free EXCEPT first five non-Saturday weekdays (Bilaga 1 carve-out).
+  if (p.month === 7) return !julyTaxedDays.has(p.day);
+  // 4. Day before a public holiday, unless one of the three explicit
+  //    Bilaga 1 carve-outs: Maundy Thursday, Ascension Eve, All Saints' Eve.
+  if (isCarveOutTaxed(p.year, p.month, p.day)) return false;
+  return isPublicHoliday(tomorrow(p));
+};
+```
+
+Helpers:
+
+- `easterSunday(year)` from `calendar/easter.ts` computes Easter via
+  Gauss's algorithm (Gauss 1800, *Berechnung des Osterfestes*; pure
+  integer arithmetic, valid 1583+).
+- Easter-derived helgdagar offsets: −2 (Good Friday), 0 (Easter Sunday),
+  +1 (Easter Monday), +39 (Ascension Day), +49 (Whit Sunday).
+- Bilaga 1 carve-outs: Maundy Thursday (Easter −3), Ascension Eve
+  (Easter +38), All Saints' Eve (Friday before All Saints' Day).
+- Midsummer Day: Saturday between Jun 20 and Jun 26 (definition in SFS
+  1989:253 §2).
+- All Saints' Day: Saturday between Oct 31 and Nov 6 (same source).
+
+Killing bug `[D§4.6]`: the reference Java's 2013-hard-coded list is
+both year-limited and **factually wrong about three days** (Maundy
+Thursday, Ascension Eve, Nov 1) per SFS 2004:629 Bilaga 1. Implementing
+the law directly fixes both at once.
+
+### Composing calendars
+
+```ts
+// calendar/combine.ts
+export const combineCalendars = (
+  ...calendars: readonly HolidayCalendar[]
+): HolidayCalendar => ({
+  isHoliday: (date) => calendars.some((c) => c.isHoliday(date)),
+});
+```
+
+The expected use case is stacking sources of holiday data — e.g. a
+jurisdiction calendar plus a company-specific calendar plus a one-off
+exception list — without callers re-implementing the union.
+
+## 4.4 Calculator
+
+```ts
+// calculator.ts
+export interface TollCalculatorOptions {
+  readonly schedule: FeeSchedule;
+  readonly calendar: HolidayCalendar;
+  readonly dailyCap: number;
+  readonly timeZone: string;
+}
+
+export interface TollCalculatorPreset extends TollCalculatorOptions {
+  readonly name: string;
+}
+
+export interface TollCalculator {
+  readonly feeFor: (vehicle: Vehicle, passes: readonly Date[]) => number;
+}
+
+export const createTollCalculator = (
+  options: TollCalculatorOptions,
+): TollCalculator => ({
+  feeFor: (vehicle, passes) => {
+    if (isTollFreeVehicle(vehicle)) return 0;
+    if (passes.length === 0) return 0;
+
+    const sorted = [...passes].sort((a, b) => a.getTime() - b.getTime());
+
+    let total = 0;
+    let windowStart = sorted[0];
+    let windowMax = feeForPass(windowStart);
+
+    for (let i = 1; i < sorted.length; i++) {
+      const pass = sorted[i];
+      const minutes = (pass.getTime() - windowStart.getTime()) / 60_000;
+
+      if (minutes <= 60) {
+        windowMax = Math.max(windowMax, feeForPass(pass));
+      } else {
+        total += windowMax;
+        windowStart = pass;
+        windowMax = feeForPass(pass);
+      }
+    }
+
+    total += windowMax;
+    return Math.min(total, options.dailyCap);
+
+    function feeForPass(date: Date): number {
+      if (options.calendar.isHoliday(date)) return 0;
+      const { hour, minute } = parts(date, options.timeZone);
+      return feeAt(options.schedule, hour, minute);
+    }
+  },
+});
+```
+
+Killing bugs `[D§4.1]`, `[D§4.2]`, `[D§4.5]`, `[D§4.8]` in one pass:
+
+- Time diff is `getTime()` in ms → exact minutes, no `Millisecond`-component
+  trap.
+- `windowStart` is reassigned when the window flips → correct windowing.
+- `total` is never decremented → no negative totals.
+- The hourly fee function is **private to the closure** → no public bypass
+  of the daily logic.
+
+## 4.5 Reference preset
+
+```ts
+// presets/reference.ts
+export const REFERENCE_PRESET: TollCalculatorPreset = {
+  name: "reference",
+  schedule: REFERENCE_FEE_SCHEDULE,
+  calendar: createSwedishCongestionTaxCalendar(),
+  dailyCap: 60,
+  timeZone: "Europe/Stockholm",
+};
+```
+
+The IANA time zone `Europe/Stockholm` is a **data property** of the preset,
+not part of the API surface. It is the zone for which the bundled schedule's
+wall-clock semantics were defined; consumers using a different rate table
+override `timeZone` (and the other fields) alongside it.
+
+## 4.6 Public surface (consumer view)
+
+```ts
+// The 90% case:
+import { createTollCalculator, REFERENCE_PRESET } from "toll-calculator";
+const calc = createTollCalculator(REFERENCE_PRESET);
+
+// Custom jurisdiction — keep the calendar, override schedule and zone:
+import { createTollCalculator, REFERENCE_PRESET } from "toll-calculator";
+const calc = createTollCalculator({
+  ...REFERENCE_PRESET,
+  schedule: MY_CITY_SCHEDULE,
+  timeZone: "Europe/Oslo",
+});
+
+// Stacking calendars:
+import {
+  createTollCalculator,
+  combineCalendars,
+  REFERENCE_PRESET,
+} from "toll-calculator";
+const calc = createTollCalculator({
+  ...REFERENCE_PRESET,
+  calendar: combineCalendars(
+    REFERENCE_PRESET.calendar,
+    myCompanyHolidayCalendar,
+  ),
+});
+```
+
+The library never names a specific city in any identifier. Geography lives
+in the data of named presets and in IANA time-zone strings.

--- a/docs/plan/05-testing-strategy.md
+++ b/docs/plan/05-testing-strategy.md
@@ -1,0 +1,139 @@
+# 5. Testing strategy
+
+Tests are the deliverable. They are also the proof that I do what I told
+the hiring manager I do.
+
+## 5.1 Test pyramid for this library
+
+```
+            ┌──────────────────┐
+            │  integration (1) │   end-to-end smoke through the public API
+            ├──────────────────┤
+            │  property  (~3)  │   windowing + cap invariants via fast-check
+            ├──────────────────┤
+            │   unit    (~30)  │   fee table, calendar, vehicle, helpers
+            └──────────────────┘
+```
+
+Unit-heavy by design. The integration test is the safety net: if every unit
+passes but the wiring is wrong, the integration test fails.
+
+## 5.2 Unit tests — per module
+
+### `fee-schedule.test.ts`
+
+- Each band returns the documented fee at its `from`, mid-point, and `to`.
+- Minutes between bands return `0`.
+- **Meta-test:** no two bands overlap.
+- **Meta-test:** bands cover 06:00–18:29 with no gaps (specifically catches
+  bug `[D§4.3]`, the "missing 09:00–14:29" hole).
+
+### `vehicle.test.ts`
+
+- Each of the six toll-free types returns `true` from `isTollFreeVehicle`.
+- `Car` returns `false`.
+- Type-level test (`expectTypeOf`) asserts the union is exhaustive.
+
+### `easter.test.ts`
+
+- Known Easter Sundays for 2013, 2024, 2025, 2030 are computed correctly.
+- 2013 in particular matches the dates hard-coded in the original Java code
+  (sanity check).
+
+### `reference-calendar.test.ts`
+
+- Every fixed holiday in 2025 (per the reference Java code) is flagged.
+- Easter-derived holidays in 2025 are flagged.
+- A normal Tuesday is not flagged.
+- A Saturday and a Sunday are flagged.
+- The **day before** a public holiday is flagged (reference-code rule).
+- The 2013 set matches the original Java hard-coded list exactly —
+  regression guarantee against the reference behavior.
+
+### `combine-calendars.test.ts`
+
+- A date flagged by **any** input calendar is flagged in the combined one.
+- A date flagged by **no** input calendar is not flagged.
+- `combineCalendars()` with zero arguments returns a calendar that flags
+  nothing (vacuous truth on `[].some(...)`).
+
+### `zoned-time.test.ts`
+
+- A `Date` whose UTC hour is 04:30 maps to wall-clock 06:30 in
+  `Europe/Stockholm` during summer time (DST).
+- A `Date` whose UTC hour is 05:30 maps to 06:30 in winter time (no DST).
+- Catches the implicit-timezone bug from the C# reference.
+
+### `calculator.test.ts`
+
+Parameterised cases ("table-driven tests"):
+
+| # | Scenario                                              | Expected |
+| - | ----------------------------------------------------- | -------- |
+| 1 | Car, single pass at 07:15 (rush)                      | 18       |
+| 2 | Car, two passes 07:15 and 07:45 (same window)         | 18       |
+| 3 | Car, passes 07:15 and 08:45 (different windows)       | 18+13=31 |
+| 4 | Car, passes 06:15, 07:30, 15:30, 17:30 (4 windows)    | 8+18+18+13=57 |
+| 5 | Car, 5+ rush passes ⇒ total > 60                       | 60 (cap) |
+| 6 | Motorbike, any time                                    | 0        |
+| 7 | Car, Saturday                                          | 0        |
+| 8 | Car, midsummer eve                                     | 0        |
+| 9 | Empty pass list                                        | 0        |
+| 10| Unordered pass list                                    | same as sorted |
+| 11| Passes spanning 01:00–05:00 (no fee window)            | 0        |
+| 12| Boundary minutes 06:00, 06:29, 06:30, 18:29, 18:30    | 8, 8, 13, 8, 0 |
+| 13| Same-millisecond duplicate passes                      | charged once |
+
+Each row is one test case via Vitest's `test.each`.
+
+## 5.3 Property tests (`fast-check`)
+
+Three properties — small, but they cover infinite cases:
+
+1. **Daily cap holds.** For any vehicle and any non-empty pass list,
+   `feeFor(v, passes) <= 60`.
+2. **Toll-free dominates.** For any toll-free vehicle and any passes,
+   `feeFor(v, passes) === 0`.
+3. **Order-independence.** For any pass list,
+   `feeFor(v, passes) === feeFor(v, shuffle(passes))`.
+4. **Monotone over windows.** Adding a pass cannot decrease the total
+   (catches a regression of `[D§4.5]`).
+
+## 5.4 Integration test
+
+One file, one test:
+
+- Build `createTollCalculator(REFERENCE_PRESET)`.
+- Three scenarios, each proving a distinct path through the preset's
+  wiring:
+  1. **Commuter day** — 6 passes on a regular weekday → 57 SEK (windowing
+     + multi-band, hand-verified, below cap).
+  2. **Holiday day** — Car on Easter Sunday → 0 (calendar wired,
+     movable feast resolved).
+  3. **Toll-free vehicle** — Motorbike on the commuter day → 0
+     (early-exit via `isTollFreeVehicle`).
+
+These tests prove the library *works as advertised* through the bundled
+preset — not just that each unit works in isolation.
+
+## 5.5 What I deliberately do not test
+
+- The standard library (`Date`, `Math.min`).
+- Internal helpers that are exercised through the public API and whose
+  behavior is verified by the unit tests of their callers.
+- Performance — irrelevant for this domain.
+
+## 5.6 Coverage target
+
+`90%+` lines, `100%` of branches in `calculator.ts` and `fee-schedule.ts`.
+Coverage is a smell detector, not a goal — chasing 100% will produce noise
+tests.
+
+## 5.7 How tests get run
+
+- `pnpm test` — runs Vitest once, exits.
+- `pnpm test:watch` — local dev loop.
+- `pnpm test:coverage` — used in CI; enforces the thresholds in `vitest.config.ts`.
+- `pnpm check` — runs `tsc --noEmit`, lint, format-check, and
+  `test:coverage`. The one-button "is the PR green?" command — identical
+  to what CI runs, so local green ⇒ CI green.

--- a/docs/plan/06-implementation-phases.md
+++ b/docs/plan/06-implementation-phases.md
@@ -1,0 +1,88 @@
+# 6. Implementation phases
+
+Work is split into phases. Each phase ends with a green `pnpm check` and
+a clean commit. Anything that does not fit a phase is scope creep.
+
+## Phase 0 — Scaffolding (≈ 30 min)
+
+- `pnpm init`, set `"type": "module"`, Node 20 engine, `packageManager: pnpm@10` (provisioned via corepack).
+- Install dev deps: typescript, vitest, @vitest/coverage-v8, eslint,
+  @typescript-eslint/*, prettier, fast-check.
+- `tsconfig.json` with the strict flags from plan §2.2.
+- `vitest.config.ts` (default + coverage thresholds).
+- `eslint.config.js` + `.prettierrc`.
+- `.gitignore` for Node.
+- Empty `src/index.ts` so `tsc --noEmit` passes.
+- First commit: `chore: scaffold TypeScript project`.
+
+## Phase 1 — Vehicle + fee schedule (≈ 45 min)
+
+- `src/vehicle.ts` with `VehicleType`, `Vehicle`, `isTollFreeVehicle`.
+- `src/fee-schedule.ts` with `FeeBand`, `FeeSchedule`, `feeAt`.
+- Tests: `vehicle.test.ts`, `fee-schedule.test.ts` (incl. meta-tests for
+  overlap/gap on the reference schedule).
+- Commit: `feat: vehicle model and fee-schedule primitives`.
+
+## Phase 2 — Zoned-time helpers (≈ 45 min)
+
+- `src/time/zoned-time.ts` — given a `Date` and an IANA zone, return
+  `{ year, month, day, hour, minute, weekday }`. Implementation uses the
+  Temporal API via `@js-temporal/polyfill` (the only runtime dep).
+- `src/time/diff.ts` — `minutesBetween(a, b)`.
+- Tests: `zoned-time.test.ts` incl. DST transitions in `Europe/Stockholm`.
+- Commit: `feat: timezone-aware date parts and minute diff`.
+
+The decision between `Intl.DateTimeFormat` (zero deps, ~60 lines of glue)
+and Temporal was settled in §2.5: Temporal wins on API clarity and
+future-proofing (the polyfill drops out when V8 ships native Temporal).
+
+## Phase 3 — Holiday calendar + combiner (≈ 1 h)
+
+- `src/calendar/index.ts` — `HolidayCalendar` interface.
+- `src/calendar/easter.ts` — Gauss's algorithm (1800) with the 1807 and 1816 corrections.
+- `src/calendar/combine.ts` — `combineCalendars` helper.
+- Tests: `easter.test.ts`, `combine-calendars.test.ts`.
+- Commit: `feat: Easter computation and combineCalendars helper`.
+
+## Phase 4 — Reference preset + calculator (≈ 1 h)
+
+- `src/calendar/swedish.ts` — `createSwedishCongestionTaxCalendar`
+  factory implementing SFS 2004:629 Bilaga 1 + SFS 1989:253 §2 with
+  cited legal sources in the JSDoc.
+- `src/presets/reference.ts` — `REFERENCE_FEE_SCHEDULE`, `REFERENCE_PRESET`
+  (wires the Swedish calendar in).
+- `src/calculator.ts` — finalize `createTollCalculator`.
+- Tests: `reference-calendar.test.ts`, `calculator.test.ts` with the
+  13-row table from plan §5.2.
+- Commit: `feat: reference preset and calculator with windowing + cap`.
+
+## Phase 5 — Property tests + integration (≈ 30 min)
+
+- `tests/calculator.property.test.ts` — the four `fast-check` properties.
+- `tests/integration.test.ts` — full-day replay.
+- Commit: `test: property tests and end-to-end integration test`.
+
+## Phase 6 — CI + README (≈ 45 min)
+
+- `.github/workflows/ci.yml` — lint, typecheck, test, coverage.
+- Root `README.md` — install, use, run tests, links to `docs/`.
+- Commit: `ci: GitHub Actions pipeline and root README`.
+
+## Phase 7 — PR (≈ 30 min)
+
+- Push branch.
+- Open PR with the body templated from
+  [`07-delivery-and-pr.md`](07-delivery-and-pr.md).
+- Notify the hiring manager and referrer by email/text.
+
+## Total time budget
+
+~6 hours of focused work. Given a week, this leaves plenty of slack for
+revisions, README polish, and second-pass cleanup.
+
+## What I will resist doing
+
+- Adding a CLI. Out of scope, distracts from the library.
+- Adding "future-proofing" config (city A vs city B). YAGNI.
+- Renaming things twice. First name sticks unless a test forces a rename.
+- Sneaking in commit messages that say "fix typo" — squash or amend instead.

--- a/docs/plan/07-delivery-and-pr.md
+++ b/docs/plan/07-delivery-and-pr.md
@@ -1,0 +1,123 @@
+# 7. Delivery and PR plan
+
+## 7.1 Branch and PR strategy
+
+- Work branch: `feat/typescript-implementation`.
+- Base: `master` of the fork.
+- One PR. Atomic commits per phase from
+  [`06-implementation-phases.md`](06-implementation-phases.md).
+- No merge commits in the PR — rebase locally before pushing.
+
+## 7.2 Commit conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/) lite:
+
+- `chore:` — scaffolding, deps, config.
+- `feat:` — new behavior.
+- `test:` — tests-only changes.
+- `ci:` — pipeline / workflow.
+- `docs:` — README, docs/.
+- `fix:` — only if a previous commit on this branch is buggy.
+
+No `wip` or `temp` commits. If a phase needs more than one commit, that is a
+sign the phase is too large.
+
+## 7.3 PR description template
+
+```markdown
+## What
+
+TypeScript implementation of the toll-fee calculator described in `README.md`,
+delivered as a Node 20 library.
+
+## Why this exists / how to read this PR
+
+Start here: [`docs/plan/`](docs/plan/) — the design exists before the code.
+Then [`docs/discovery/`](docs/discovery/) — bugs found in the reference
+C# / Java code.
+
+## Bugs in the reference code (all absent in this PR)
+
+- [`docs/discovery/04-bugs.md`](docs/discovery/04-bugs.md) §4.1 — `DateTime.Millisecond` time-diff bug in C#.
+- §4.2 — `intervalStart` never advanced.
+- §4.3 — fee table forgets minutes 00–29 of hours 9–14.
+- §4.4 — no defensive handling of empty / unsorted input.
+- §4.5 — totals can go negative.
+- §4.6 — holidays hard-coded to 2013.
+- §4.7 — stringly-typed vehicle exemption.
+- §4.8 — single-pass overload is public and bypasses the daily rules.
+
+## Design decisions
+
+- TypeScript 6, Node 20, ESM, strict mode incl. `noUncheckedIndexedAccess`
+  and `verbatimModuleSyntax`.
+- Fee schedule is data, not control flow.
+- Holiday calendar is an injectable `HolidayCalendar` interface; the
+  bundled `createSwedishCongestionTaxCalendar` factory derives every
+  toll-free day directly from Swedish primary legislation (SFS 2004:629
+  Bilaga 1 + SFS 1989:253 §2), generalized to any Gregorian year.
+  Easter is computed via Gauss's algorithm in `calendar/easter.ts`.
+  No class, just an object literal returned by a factory.
+- Public API is jurisdiction-agnostic. The bundled `REFERENCE_PRESET`
+  carries the rates / calendar / cap / time zone derived from the
+  reference Java / C# code; a new jurisdiction is a new preset file,
+  zero library changes.
+- `combineCalendars(...calendars)` composes holiday sources without
+  callers re-implementing the union.
+- All time arithmetic in UTC milliseconds; wall-clock interpretation in
+  the preset-supplied IANA zone via the Temporal API (`@js-temporal/polyfill`,
+  the library's only runtime dependency — drops out when V8 ships native
+  Temporal).
+
+## Assumptions where the README is silent
+
+- The README mentions SEK and never names a country or city; the bundled
+  rates and calendar reproduce what the Java / C# reference code
+  contains. Other jurisdictions are supported by exporting new presets.
+- Empty pass list → `0` (no error).
+- Unsorted pass list → sorted internally; caller's array is not mutated.
+- The day before a public holiday is also toll-free (reproduces the
+  reference code's behavior).
+- Daily cap of 60 applies after windowing (one-pass clamp).
+
+## How to run
+
+```
+corepack enable        # provisions pnpm 10 (no global install needed)
+pnpm install
+pnpm test              # unit + property + integration
+pnpm check             # typecheck + lint + format + test:coverage
+```
+
+## What I will discuss in the follow-up meeting
+
+- Why I rewrote rather than translated.
+- How `docs/` was used to brief the AI before writing code.
+- Trade-offs around `Intl.DateTimeFormat` vs Temporal / Luxon.
+- What I would add if this were a real product (CLI, REST adapter, telemetry).
+```
+
+## 7.4 Pre-push checklist
+
+- [ ] `pnpm check` is green locally.
+- [ ] Coverage report ≥ 90% lines / 100% branches on `calculator.ts`.
+- [ ] No commented-out code.
+- [ ] No `console.log` left in `src/`.
+- [ ] `README.md` install/test commands actually work in a fresh clone.
+- [ ] `git log --oneline` reads like a short story of the work.
+- [ ] CI is green on the pushed branch before opening the PR.
+
+## 7.5 Notifying the reviewers
+
+After the PR is open:
+
+- Notify the hiring manager and referrer with the PR URL and one line of context.
+- Mention the `docs/` folder explicitly — that is the differentiator.
+- Offer to walk through it live.
+
+## 7.6 What I will not do
+
+- Force-push after the PR is open. If a fix is needed, push a follow-up
+  commit and let reviewers see the history.
+- Open multiple PRs. One coherent deliverable.
+- Squash on push. Reviewers can squash on merge if they prefer.

--- a/docs/plan/08-github-automations.md
+++ b/docs/plan/08-github-automations.md
@@ -1,0 +1,227 @@
+# 8. GitHub Actions — automation layer
+
+A dedicated automation surface lives in `.github/`. It is treated as
+**product code**, not as an afterthought: workflows are linted, pinned, and
+documented. The goal is that the repo polices itself so reviewers only
+ever look at *intentional* signal.
+
+## 8.1 What "automation layer" means here
+
+Five concerns, each with one workflow file:
+
+| File                              | Purpose                                                |
+| --------------------------------- | ------------------------------------------------------ |
+| `.github/workflows/ci.yml`        | Lint + typecheck + test on every push / PR             |
+| `.github/workflows/coverage.yml`  | Coverage report as PR comment + summary                |
+| `.github/workflows/codeql.yml`    | Static security analysis (GitHub-hosted)               |
+| `.github/workflows/release.yml`   | Tag + GitHub Release on `v*` push (manual cut)         |
+| `.github/workflows/stale.yml`     | Close abandoned PRs/issues after N days                |
+
+Plus three configuration files:
+
+| File                              | Purpose                                                |
+| --------------------------------- | ------------------------------------------------------ |
+| `.github/dependabot.yml`          | Weekly bumps for npm + actions                         |
+| `.github/CODEOWNERS`              | Auto-request review from me on any src/ change         |
+| `.github/pull_request_template.md`| Forces the PR description from plan §7.3               |
+
+## 8.2 Conventions for every workflow
+
+- **Pin actions by SHA**, not by tag. Tags are mutable, SHAs are not. Both
+  are kept fresh by Dependabot.
+- **Set `permissions:` at the workflow level** to the minimum. Default is
+  `read`; specific jobs widen as needed.
+- **Cache `~/.npm`** keyed by `package-lock.json` hash.
+- **Concurrency group** per ref so a new push cancels the previous run.
+- **Single Node version** (20) — matches the runtime declared in
+  `package.json` `engines`.
+
+## 8.3 `ci.yml` — the gate
+
+Reflects what actually ships in `.github/workflows/ci.yml`. The job
+working directory is `TypeScript/` because the package lives in a
+sub-folder of the repo (the `Java/` and `C#/` reference folders share
+the same root).
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Type-check, lint, format and test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: TypeScript
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable                    # provisions pnpm 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: TypeScript/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run typecheck
+      - run: pnpm run lint
+      - run: pnpm run format:check
+      - run: pnpm run test:coverage
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: TypeScript/coverage/
+          retention-days: 7
+```
+
+The CI job is **the** required status check for branch protection.
+
+## 8.4 `coverage.yml` — visible feedback
+
+- Triggered by `workflow_run` after `ci.yml` succeeds on a PR.
+- Downloads the `coverage/` artifact.
+- Posts (or updates) a single PR comment with a summary table.
+- Fails the workflow if line coverage drops below the threshold declared in
+  `vitest.config.ts` (90%).
+
+Why a separate workflow: keeps `ci.yml` fast and read-only; the comment
+needs `pull-requests: write`, which we do not want in the gate.
+
+## 8.5 `codeql.yml` — security baseline
+
+- GitHub's default JS/TS CodeQL template.
+- Runs on PR + weekly cron.
+- Out-of-the-box value; zero maintenance.
+
+## 8.6 `release.yml` — manual cut
+
+- Triggered on tag push matching `v*`.
+- Builds the package, runs the full check, creates a GitHub Release with the
+  changelog generated from commits since the previous tag (Conventional
+  Commits already in place from plan §7.2).
+- No npm publish — this is a single deliverable, not a published package.
+  Adding the publish step later is a one-liner once an npm token is
+  available.
+
+## 8.7 `stale.yml` — hygiene
+
+- Marks PRs/issues stale after 30 days of inactivity, closes after 7 more.
+- Skipped for anything labeled `pinned` or `security`.
+- Almost certainly never fires during the review cycle, but it costs
+  nothing and shows the discipline.
+
+## 8.8 `dependabot.yml`
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule: { interval: weekly }
+    open-pull-requests-limit: 5
+    groups:
+      dev-deps:
+        dependency-type: development
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule: { interval: weekly }
+```
+
+Dev deps are grouped to avoid PR noise.
+
+## 8.9 Branch protection (configured in repo settings)
+
+Documented here so the configuration is reproducible:
+
+- `master` requires:
+  - PR before merge.
+  - 1 approval from a reviewer.
+  - `CI / check` status green.
+  - `CodeQL` analysis green.
+  - Linear history (no merge commits).
+  - Dismiss stale reviews on new commit.
+- Force pushes: disabled.
+- Deletions: disabled.
+
+These settings are not in code (GitHub doesn't expose them in workflow
+files), but they are documented and can be replayed via the `gh` CLI.
+
+## 8.10 `CODEOWNERS`
+
+```
+# Anything in src/ requires my review.
+/src/        @<my-github-handle>
+/.github/    @<my-github-handle>
+/docs/       @<my-github-handle>
+```
+
+## 8.11 PR template
+
+`.github/pull_request_template.md` mirrors the structure from
+[`07-delivery-and-pr.md`](07-delivery-and-pr.md) §7.3 so every future PR
+shows: **What**, **Why**, **Bugs in reference (if any)**, **Decisions**,
+**Assumptions**, **How to run**.
+
+## 8.12 Local mirror of CI
+
+`pnpm check` runs the **exact** sequence CI runs:
+`typecheck → lint → format:check → test:coverage`. No "works on my
+machine" surprises. The `check` script in `package.json` is intentionally
+the same composition CI invokes step-by-step, so local green ⇒ CI green.
+
+## 8.13 What this layer is *not*
+
+- It is not a Kubernetes pipeline. No deploy step, no env matrix.
+- It is not a release-please / changesets setup. The project is a single
+  package, one release per tag, no semver automation.
+- It is not exhaustive — additions (Slack notifications, preview deploys,
+  performance benchmarks) are deliberately out of scope for this
+  deliverable.
+
+## 8.14 Cost vs. value
+
+| Workflow      | Setup cost | Long-term value | Decision |
+| ------------- | ---------- | --------------- | -------- |
+| `ci.yml`      | 15 min     | Mandatory       | **In**   |
+| `coverage.yml`| 20 min     | High signal     | **In**   |
+| `codeql.yml`  | 5 min      | Free baseline   | **In**   |
+| `release.yml` | 20 min     | Real when shipping | **In** (light version) |
+| `stale.yml`   | 5 min      | Low but free    | **In**   |
+| `dependabot`  | 5 min      | High            | **In**   |
+| `CODEOWNERS`  | 2 min      | Required for review automation | **In** |
+| PR template   | 5 min      | Sets the tone   | **In**   |
+
+Total: ~80 minutes of setup, mostly during phase 6 of
+[`06-implementation-phases.md`](06-implementation-phases.md). I will fold
+this work into that phase and bump its budget from 45 minutes to ~1h45m.
+
+## 8.15 What shipped vs. what stayed as roadmap
+
+Sections 9.1–9.14 describe the **target** automation surface. For
+this deliverable, only the load-bearing piece shipped:
+
+| File                                | Shipped? | Note                                                                |
+| ----------------------------------- | -------- | ------------------------------------------------------------------- |
+| `.github/workflows/ci.yml`          | ✅       | The required gate. Mirrors `pnpm check` exactly.                    |
+| `.github/workflows/coverage.yml`    | ❌ roadmap | CI already uploads the coverage artifact (§8.3); a separate PR-comment workflow is the next step but not needed to merge. |
+| `.github/workflows/codeql.yml`      | ❌ roadmap | One-liner enable in repo settings; left out to keep PR diff focused on the deliverable. |
+| `.github/workflows/release.yml`     | ❌ roadmap | Not a published package today (`package.json` has no `dist/` build). |
+| `.github/workflows/stale.yml`       | ❌ roadmap | Cosmetic; this is a single PR, no backlog hygiene need.             |
+| `.github/dependabot.yml`            | ❌ roadmap | Sensible default but out of scope for this review.                   |
+| `.github/CODEOWNERS`                | ❌ roadmap | Single-author repo; nobody to route reviews to.                      |
+| `.github/pull_request_template.md`  | ❌ roadmap | The PR body uses the template from §7.3 manually; auto-enforcing it is a follow-up. |
+
+The split is deliberate: §8.1–§8.13 documents the **discipline** I would
+bring to a production repo; §8.15 documents what was load-bearing for
+*this* deliverable. The reviewer can read either as the level of
+ambition matches the conversation we have in the follow-up meeting.

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -1,0 +1,31 @@
+# Plan — TypeScript implementation
+
+Concrete plan for the deliverable. This is the document I would hand a
+collaborator (human or AI) before writing any code, so that the rewrite is
+**production-grade** instead of a literal translation of the reference.
+
+## Index
+
+1. [Context and goals](01-context-and-goals.md)
+2. [Tech stack](02-tech-stack.md)
+3. [Architecture](03-architecture.md)
+4. [Domain model and API](04-domain-model.md)
+5. [Testing strategy](05-testing-strategy.md)
+6. [Implementation phases](06-implementation-phases.md)
+7. [Delivery and PR plan](07-delivery-and-pr.md)
+8. [GitHub Actions — automation layer](08-github-automations.md)
+
+Supporting reference:
+
+- [Legal references for the Swedish calendar](legal-references.md) —
+  primary-source ledger (SFS 2004:629 + SFS 1989:253) for the rules
+  implemented in `src/calendar/swedish.ts`.
+
+The methodology that produced this plan — context-first AI
+collaboration, harness components, and operating rules — lives one
+level up in [`../HARNESS.md`](../HARNESS.md), because it transcends
+this specific module and would apply to any other.
+
+Cross-references to discovery findings use `[D§n.m]` notation —
+e.g. `[D§4.1]` is bug 4.1 in
+[`../discovery/04-bugs.md`](../discovery/04-bugs.md).

--- a/docs/plan/legal-references.md
+++ b/docs/plan/legal-references.md
@@ -1,0 +1,111 @@
+# Legal references — Swedish congestion-tax calendar
+
+This file is the primary-source ledger for the toll-free-day rules
+implemented in `src/calendar/swedish.ts`. Everything that the JSDoc in
+that file abbreviates with a citation is spelled out here, in full.
+
+Bug [D§4.6] in discovery only observes that the reference Java code
+hard-codes the year 2013 — it does **not** answer "what is the correct
+rule." That answer lives here, because it is the result of legal
+research, not of reading the Java source.
+
+---
+
+## 1. Governing statutes
+
+### 1.1 SFS 2004:629 — *Lag om trängselskatt* (Congestion-Tax Act)
+
+The act that establishes the congestion tax and, in **Bilaga 1**
+(Annex 1), enumerates the carve-outs for the Stockholm zone: which
+days are toll-free, which hours apply on the days that are taxed,
+and the July clause.
+
+- Riksdagen source:
+  https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-2004629-om-trangselskatt_sfs-2004-629/
+
+Relevant excerpts (Bilaga 1):
+
+> *"Skatt ska inte tas ut på lördagar, helgdagar, dagar före helgdag
+> eller under juli månad. Skatt ska dock tas ut på dagen efter
+> långfredag (skärtorsdagen), dagen före Kristi himmelsfärds dag och
+> dagen före allhelgonadagen, samt under de fem första vardagarna
+> utom lördag i juli månad."*
+
+In plain terms:
+- Saturdays, public holidays, and the day before a public holiday are
+  toll-free.
+- July is toll-free **except** for the first five weekdays
+  (Mon–Fri) of the month.
+- Three day-before-holiday cases are explicitly **taxed**:
+  Maundy Thursday, Ascension Eve, All Saints' Eve.
+
+### 1.2 SFS 1989:253 — *Lag om allmänna helgdagar* (Public Holidays Act)
+
+Defines what counts as a *helgdag* (public holiday) in Sweden. SFS
+2004:629 Bilaga 1 references "helgdag" without redefining it, so the
+1989 act is the authoritative enumeration.
+
+- Riksdagen source:
+  https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/
+
+§2 enumerates the *helgdagar*:
+- Söndagar (every Sunday).
+- Nyårsdagen (Jan 1).
+- Trettondedag jul / Epiphany (Jan 6).
+- Långfredagen (Good Friday).
+- Påskdagen (Easter Sunday).
+- Annandag påsk (Easter Monday).
+- Första maj (May 1).
+- Kristi himmelsfärds dag (Ascension Day — Easter + 39 days).
+- Pingstdagen (Whitsunday — Easter + 49 days).
+- Sveriges nationaldag (Jun 6).
+- Midsommardagen (Midsummer Day — Saturday between Jun 20 and Jun 26).
+- Alla helgons dag (All Saints' Day — Saturday between Oct 31 and Nov 6).
+- Juldagen (Dec 25).
+- Annandag jul (Dec 26).
+
+---
+
+## 2. Divergences between the Java reference 2013 list and the law
+
+The Java reference's hard-coded 2013 list was compared against the
+two statutes above. Four divergences emerge:
+
+| # | Divergence | What Java does | What the law says |
+|---|------------|----------------|-------------------|
+| 1 | **Epiphany missing.** | Jan 6 is not in the 2013 list. In 2013 it fell on a Sunday so the weekend rule masked it; in 2025 it falls on Monday and Java wrongly bills it. | SFS 1989:253 §2 lists *Trettondedag jul* as a *helgdag*. |
+| 2 | **Day-before-holiday not a rule.** | The eve dates that appear (Apr 30, Jun 5, Dec 24, Dec 31, Nov 1) are individual hard-coded entries. Epiphany Eve (Jan 5) is missing. | SFS 2004:629 Bilaga 1 says *dag före helgdag* is toll-free, derived from the helgdag list. |
+| 3 | **Three eves are taxed, not free.** | Java's 2013 list includes Mar 28 (Maundy Thursday), May 8 (Ascension Eve), and Nov 1 (All Saints' Eve) as toll-free. | SFS 2004:629 Bilaga 1 carves these out explicitly as taxable. |
+| 4 | **July is fully free.** | Java treats the entire month of July as toll-free. | SFS 2004:629 Bilaga 1: *"under de fem första vardagarna utom lördag i juli månad"* — the first five non-Saturday weekdays of July are taxed. |
+
+---
+
+## 3. How the implementation pins to these sources
+
+`src/calendar/swedish.ts` opens with a JSDoc citation block that names
+both SFS numbers and links back to this file. Each rule in the
+algorithm is annotated with the clause it derives from:
+
+```text
+1. Sunday        → SFS 1989:253 §2
+2. Public holiday → SFS 1989:253 §2 enumeration
+3. July clause   → SFS 2004:629 Bilaga 1
+4. Day before holiday, with Maundy Thursday / Ascension Eve /
+   All Saints' Eve carve-outs → SFS 2004:629 Bilaga 1
+```
+
+The test suite verifies each carve-out explicitly against dated
+samples from 2013, 2024, 2025, and 2027 so that any regression — for
+instance, accidentally re-introducing the Java behavior — fails a
+named test rather than silently changing outputs.
+
+---
+
+## 4. Why this lives in `plan/`, not `discovery/`
+
+Discovery's job is to record what the reference code *does* — the
+year-2013 hard-coding is observable from reading
+`Java/TollCalculator.java:77`. The reason the 2013 list itself is
+also wrong — i.e. the law it *fails* to implement — required reading
+Swedish statutes, not reading the reference code. That research is a
+**deliverable of the plan**, so it belongs in this directory.


### PR DESCRIPTION
## Summary

TypeScript rewrite of the toll-fee calculator described in `README.md`,
delivered as a Node 20 library. The reference C# / Java code is treated
as adversarial input — analyzed, its bugs enumerated, and the rewrite
built from the README's business rules plus Swedish primary legislation,
not from line-by-line translation.

## How to run

```bash
cd TypeScript
corepack enable        # provisions pnpm 10
pnpm install
pnpm test              # 133 tests: unit + property + integration
pnpm check             # typecheck + lint + format + test:coverage
```

## How to read this PR

The `docs/` folder is the entry point. Three layers, in order:

1. **[`docs/HARNESS.md`](docs/HARNESS.md)** — the AI-collaboration methodology used here. Context-first, victory conditions as executable checks, primary-source citation discipline. Applies to any module, not just this one.
2. **[`docs/discovery/`](docs/discovery/)** — static analysis of the bundled Java/C# reference: business rules from the README, eight enumerated bugs, code smells, rewrite recommendation.
3. **[`docs/plan/`](docs/plan/)** — the implementation plan for this module: tech stack, architecture, domain model, testing strategy, phases, delivery, CI. Plus [`legal-references.md`](docs/plan/legal-references.md), the primary-source ledger for the Swedish calendar (SFS 2004:629 + SFS 1989:253).

The implementation lives in [`TypeScript/`](TypeScript/). Build/test instructions in [`TypeScript/README.md`](TypeScript/README.md).

## Bugs in the reference 

References are to `docs/discovery/04-bugs.md` §4.x:

- **§4.1** — `DateTime.Millisecond` time-diff in C# (`TollCalculator.cs:25-26`). Always 0, so the once-per-hour rule never advances.
- **§4.2** — `intervalStart` is set once and never reassigned. Every comparison is against the first pass of the day.
- **§4.3** — fee-table conditions broken in two places: drops the 00–29 minute slot of hours 9–14; operator-precedence bug makes the 15:00–16:59 branch unreachable.
- **§4.4** — no defensive handling of empty / unsorted input. `dates[0]` throws on empty array.
- **§4.5** — totals can go negative when `tempFee > totalFee`.
- **§4.6** — holiday calendar hard-coded to year 2013.
- **§4.7** — vehicle exemption by stringly-typed comparison. Any typo silently breaks the exemption.
- **§4.8** — single-pass `getTollFee` overload is public; callers can bypass the once-per-hour and daily-cap rules.

## Calendar — divergence from the Java reference

The most consequential finding. The Java 2013 holiday list doesn't just expire — **it contradicts the law it was meant to implement**. The toll system is governed by:

- **SFS 2004:629** *Lag om trängselskatt*, Bilaga 1 ([riksdagen.se](https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-2004629-om-trangselskatt_sfs-2004-629/))
- **SFS 1989:253** *Lag om allmänna helgdagar*, §2 ([riksdagen.se](https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/))

Four divergences between the Java list and primary law:

1. **Epiphany (Jan 6) is missing.** SFS 1989:253 §2 lists *Trettondedag jul* as a *helgdag*. In 2013 it fell on Sunday so the weekend rule masked the omission; in 2025 it falls on Monday and the Java code bills it.
2. **Day-before-holiday is a one-off enumeration, not a derived rule.** Eves are hard-coded individually — Epiphany Eve (Jan 5) is missing.
3. **Three eves are explicitly taxed by Bilaga 1 but flagged free by Java**: Maundy Thursday, Ascension Eve, All Saints' Eve. Verbatim: *"Skatt ska tas ut för dag före långfredagen, dag före Kristi himmelsfärds dag och dag före alla helgons dag."*
4. **July clause inverted.** Java treats all of July as toll-free. Bilaga 1: *"Under juli månad ska ingen skatt tas ut förutom för de fem första vardagarna utom lördag i den månaden."* — the first five non-Saturday weekdays of July ARE taxed.

The `createSwedishCongestionTaxCalendar` factory ([`TypeScript/src/calendar/swedish.ts`](TypeScript/src/calendar/swedish.ts)) derives every toll-free day from these two statutes for any Gregorian year. Each divergence is covered by a dated test in [`TypeScript/tests/reference-calendar.test.ts`](TypeScript/tests/reference-calendar.test.ts) and exercised through the public API by [`TypeScript/tests/integration.test.ts`](TypeScript/tests/integration.test.ts).

## Design decisions

- **TypeScript 6, Node 20 LTS, ESM, pnpm 10**
- **Fee schedule is data, not control flow.** Declarative array of `{ from, to, fee }` bands; lookup via `feeAt(schedule, hour, minute)`.
- **Holiday calendar is injectable.** One-method interface (`isHoliday(date) => boolean`); stack sources via `combineCalendars`.
- **Public API is jurisdiction-agnostic.** A new city is `{ ...REFERENCE_PRESET, schedule: MY_SCHEDULE, timeZone: "Europe/Oslo" }`. No library changes.
- **Boundary validation separated from internals.** `src/validation.ts` runtime-checks `unknown` shapes at the public surface (JSON.parse, ORM rows, plain-JS callers); internal helpers trust their types.
- **Time arithmetic in UTC milliseconds; wall-clock interpretation in the preset's IANA time zone.** The 60-minute window between passes is DST-stable; fee-schedule bands are zone-aware (`06:30` means local 06:30).

## Tests

- **Outside-in narrative.** The integration suite lands before the per-module unit tests in the commit log, matching the testing approach described in the brief.
- **15 integration tests** exercising every public-API path: windowing, daily cap, all four calendar branches (weekend, helgdag, day-before, July clause), DST transitions, input validation, toll-free vehicles.
- **Unit tests cover the function and the bundled data separately.** `feeAt` is tested against a minimal hand-rolled schedule so failures isolate the lookup logic; `REFERENCE_FEE_SCHEDULE` has its own tests that verify properties of the data itself (every minute 06:00–18:29 covered exactly once). Same pattern applied to the Swedish calendar in `tests/reference-calendar.test.ts`.
- **Property-based tests** (fast-check) verify four rules that must hold for any input: total ≤ daily cap, toll-free vehicles return 0, pass order doesn't change the result, adding a pass never decreases the total.
- **Coverage gate**: 90% global, 100% on `calculator.ts` and `fee-schedule.ts`. Enforced by `pnpm check` locally and CI.
- **133 tests · 100% line coverage · 98.71% branch coverage.**

## Assumptions where the README is silent

- **Country / timezone.** README mentions SEK and never names a country. The bundled preset reproduces the Java reference's de-facto Sweden + `Europe/Stockholm`. Other jurisdictions are new preset files.
- **Empty pass list** → `0` (no error).
- **Unsorted pass list** → sorted internally; the caller's array is not mutated.
- **Single-day contract.** `feeFor(vehicle, passes)` expects passes from one billing day; the daily cap is applied to what it receives.
- **Day-before-holiday is toll-free** as a derived rule, with the three SFS 2004:629 Bilaga 1 carve-outs explicitly taxed.

